### PR TITLE
fix(android): harden download polling against DB crashes and zombie rows

### DIFF
--- a/__tests__/integration/models/downloadZombieRecovery.test.ts
+++ b/__tests__/integration/models/downloadZombieRecovery.test.ts
@@ -1,0 +1,76 @@
+const mockBackgroundDownloadService = {
+  isAvailable: jest.fn(),
+  getActiveDownloads: jest.fn(),
+};
+
+jest.mock('../../../src/services/backgroundDownloadService', () => ({
+  backgroundDownloadService: mockBackgroundDownloadService,
+}));
+
+const { hydrateDownloadStore } = require('../../../src/services/downloadHydration');
+const { useDownloadStore } = require('../../../src/stores/downloadStore');
+const { isRetryable } = require('../../../src/utils/downloadErrors');
+
+describe('download zombie recovery integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useDownloadStore.setState({
+      downloads: {},
+      downloadIdIndex: {},
+      repairingVisionIds: {},
+    });
+    mockBackgroundDownloadService.isAvailable.mockReturnValue(true);
+  });
+
+  it('hydrates interrupted downloads as failed with a retryable reason code', async () => {
+    mockBackgroundDownloadService.getActiveDownloads.mockResolvedValue([
+      {
+        downloadId: 'dl-zombie-1',
+        modelId: 'qwen3-4b',
+        modelKey: 'qwen3-4b:Q4_K_M.gguf',
+        fileName: 'Q4_K_M.gguf',
+        modelType: 'text',
+        status: 'failed',
+        bytesDownloaded: 0,
+        totalBytes: 2_500_000_000,
+        reason: 'The download was interrupted.',
+        reasonCode: 'download_interrupted',
+        createdAt: 1_700_000_000_000,
+      },
+    ]);
+
+    await hydrateDownloadStore();
+
+    const entry = useDownloadStore.getState().downloads['qwen3-4b:Q4_K_M.gguf'];
+    expect(entry).toBeDefined();
+    expect(entry.status).toBe('failed');
+    expect(entry.errorCode).toBe('download_interrupted');
+    expect(entry.errorMessage).toBe('The download was interrupted.');
+    expect(isRetryable(entry.errorCode)).toBe(true);
+  });
+
+  it('does not drop failed rows so the Download Manager can show retry', async () => {
+    mockBackgroundDownloadService.getActiveDownloads.mockResolvedValue([
+      {
+        downloadId: 'dl-zombie-2',
+        modelId: 'whisper-base',
+        modelKey: 'whisper-base:ggml-base.en.bin',
+        fileName: 'ggml-base.en.bin',
+        modelType: 'stt',
+        status: 'failed',
+        bytesDownloaded: 32,
+        totalBytes: 148_000_000,
+        reason: 'The download was interrupted.',
+        reasonCode: 'download_interrupted',
+        createdAt: 1_700_000_000_100,
+      },
+    ]);
+
+    await hydrateDownloadStore();
+
+    expect(Object.keys(useDownloadStore.getState().downloads)).toHaveLength(1);
+    expect(useDownloadStore.getState().downloadIdIndex['dl-zombie-2']).toBe(
+      'whisper-base:ggml-base.en.bin',
+    );
+  });
+});

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt
@@ -312,12 +312,40 @@ class DownloadManagerModule(reactContext: ReactApplicationContext) :
     @ReactMethod
     fun startProgressPolling() {
         scope.launch {
-            val active = withContext(Dispatchers.IO) {
-                downloadDao.getAllDownloads().first().filter {
-                    it.status == DownloadStatus.QUEUED || it.status == DownloadStatus.RUNNING
+            try {
+                val active = withContext(Dispatchers.IO) {
+                    downloadDao.getAllDownloads().first().filter {
+                        it.status == DownloadStatus.QUEUED || it.status == DownloadStatus.RUNNING
+                    }
                 }
+                for (download in active) {
+                    if (workObservers.containsKey(download.id)) continue
+                    val workInfos = withContext(Dispatchers.IO) {
+                        workManager.getWorkInfosForUniqueWork(WorkerDownload.workName(download.id)).get()
+                    }
+                    if (DownloadPolling.isZombieWorkStates(workInfos.map { it.state })) {
+                        withContext(Dispatchers.IO) {
+                            downloadDao.updateStatus(
+                                download.id,
+                                DownloadStatus.FAILED,
+                                DownloadReason.DOWNLOAD_INTERRUPTED,
+                            )
+                        }
+                        DownloadEventBridge.error(
+                            download.id,
+                            download.fileName,
+                            download.modelId,
+                            DownloadReason.messageFor(DownloadReason.DOWNLOAD_INTERRUPTED)
+                                ?: "Download was interrupted.",
+                            DownloadReason.DOWNLOAD_INTERRUPTED,
+                        )
+                    } else {
+                        registerObserver(download.id, download.fileName, download.modelId)
+                    }
+                }
+            } catch (_: Exception) {
+                // DB unavailable — polling skipped, no crash
             }
-            active.forEach { if (!workObservers.containsKey(it.id)) registerObserver(it.id, it.fileName, it.modelId) }
         }
     }
 

--- a/android/app/src/main/java/ai/offgridmobile/download/DownloadPolling.kt
+++ b/android/app/src/main/java/ai/offgridmobile/download/DownloadPolling.kt
@@ -1,0 +1,14 @@
+package ai.offgridmobile.download
+
+import androidx.work.WorkInfo
+
+/**
+ * Pure helpers for [DownloadManagerModule.startProgressPolling].
+ * Extracted so zombie-detection rules are unit-testable without Room/WorkManager.
+ */
+internal object DownloadPolling {
+    fun isZombieWorkStates(states: List<WorkInfo.State>): Boolean =
+        states.isEmpty() || states.all {
+            it == WorkInfo.State.CANCELLED || it == WorkInfo.State.FAILED
+        }
+}

--- a/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
+++ b/android/app/src/test/java/ai/offgridmobile/download/DownloadManagerModuleTest.kt
@@ -1,6 +1,7 @@
 package ai.offgridmobile.download
 
 import android.app.Application
+import androidx.work.WorkInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -302,6 +303,76 @@ class DownloadManagerModuleTest {
         val mgr = ctx.getSystemService(android.content.Context.NOTIFICATION_SERVICE)
             as android.app.NotificationManager
         assertNotNull(mgr.getNotificationChannel("model_downloads"))
+    }
+
+    // ── DownloadPolling.isZombieWorkStates ────────────────────────────────────
+
+    @Test
+    fun isZombieWorkStatesTreatsEmptyListAsZombie() {
+        assertTrue(DownloadPolling.isZombieWorkStates(emptyList()))
+    }
+
+    @Test
+    fun isZombieWorkStatesTreatsAllCancelledAsZombie() {
+        assertTrue(
+            DownloadPolling.isZombieWorkStates(
+                listOf(WorkInfo.State.CANCELLED, WorkInfo.State.CANCELLED),
+            ),
+        )
+    }
+
+    @Test
+    fun isZombieWorkStatesTreatsAllFailedAsZombie() {
+        assertTrue(
+            DownloadPolling.isZombieWorkStates(
+                listOf(WorkInfo.State.FAILED),
+            ),
+        )
+    }
+
+    @Test
+    fun isZombieWorkStatesTreatsMixedCancelledAndFailedAsZombie() {
+        assertTrue(
+            DownloadPolling.isZombieWorkStates(
+                listOf(WorkInfo.State.CANCELLED, WorkInfo.State.FAILED),
+            ),
+        )
+    }
+
+    @Test
+    fun isZombieWorkStatesRejectsRunningWork() {
+        assertFalse(
+            DownloadPolling.isZombieWorkStates(
+                listOf(WorkInfo.State.RUNNING),
+            ),
+        )
+    }
+
+    @Test
+    fun isZombieWorkStatesRejectsEnqueuedWork() {
+        assertFalse(
+            DownloadPolling.isZombieWorkStates(
+                listOf(WorkInfo.State.ENQUEUED),
+            ),
+        )
+    }
+
+    @Test
+    fun isZombieWorkStatesRejectsCancelledPlusRunning() {
+        assertFalse(
+            DownloadPolling.isZombieWorkStates(
+                listOf(WorkInfo.State.CANCELLED, WorkInfo.State.RUNNING),
+            ),
+        )
+    }
+
+    @Test
+    fun downloadInterruptedReasonIsRetryable() {
+        assertTrue(DownloadReason.isRetryable(DownloadReason.DOWNLOAD_INTERRUPTED))
+        assertEquals(
+            "The download was interrupted.",
+            DownloadReason.messageFor(DownloadReason.DOWNLOAD_INTERRUPTED),
+        )
     }
 }
 

--- a/docs/PENDING_FIXES.md
+++ b/docs/PENDING_FIXES.md
@@ -4,7 +4,8 @@ Issues identified but not yet applied to code. Address before or alongside the n
 
 ---
 
-## 1. SQLiteException not caught in `startProgressPolling`
+## ~~1. SQLiteException not caught in `startProgressPolling`~~ ✅ Fixed in `fix/android-download-zombie-polling`
+
 
 **File:** `android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt`
 
@@ -36,7 +37,8 @@ fun startProgressPolling() {
 
 ---
 
-## 2. Zombie download entries after app update
+## ~~2. Zombie download entries after app update~~ ✅ Fixed in `fix/android-download-zombie-polling`
+
 
 **File:** `android/app/src/main/java/ai/offgridmobile/download/DownloadManagerModule.kt`
 


### PR DESCRIPTION
## Summary

- Wrap `startProgressPolling` in try/catch so a Room/SQLite migration failure cannot crash the app on launch (documented in `docs/PENDING_FIXES.md` #1).
- Before registering WorkManager observers, synchronously check each active DB row; if WorkManager has no task or only CANCELLED/FAILED work, mark the row `FAILED` with `download_interrupted` and emit an error event so ghost downloads show a retry button instead of staying stuck forever (#2).
- Extract `DownloadPolling.isZombieWorkStates` as a pure helper with Android unit tests.
- Add a JS integration test verifying interrupted downloads hydrate into the download store as failed + retryable.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Relates to #420 (Android download manager reliability)

## Test plan

- [x] `npx jest __tests__/integration/models/downloadZombieRecovery.test.ts` passes locally
- [ ] `cd android && ./gradlew :app:testDebugUnitTest --tests "ai.offgridmobile.download.DownloadManagerModuleTest"` (requires Android SDK)
- [ ] Manual: install an app update while a download is running; confirm stuck entries become failed with retry
- [ ] Manual: confirm app does not crash if download DB migration fails on first poll

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of Changes

* **Bug Fixes**
  * Improved download recovery after restarts by detecting “zombie” background work and restoring affected downloads as failed (with retryable status).
  * Download progress polling now fails more gracefully if errors occur, reducing crash risk.

* **Tests**
  * Added unit/integration coverage for zombie download detection, retryability, and hydration of interrupted downloads.

* **Documentation**
  * Updated the pending fixes list to mark the completed download-related items as resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->