### PR TITLE
fix(android): Pixel/Tensor image gen MNN CPU path and clear labeling

### DIFF
--- a/__tests__/integration/models/pixel10ImageGenCpuPath.test.ts
+++ b/__tests__/integration/models/pixel10ImageGenCpuPath.test.ts
@@ -1,0 +1,46 @@
+import { Platform } from 'react-native';
+import DeviceInfo from 'react-native-device-info';
+import { hardwareService } from '../../../src/services/hardware';
+
+const originalOS = Platform.OS;
+
+jest.mock('react-native-device-info', () => ({
+  getModel: jest.fn(() => 'Pixel 10 Pro XL'),
+  getHardware: jest.fn(async () => 'tensor'),
+  getTotalMemory: jest.fn(async () => 12 * 1024 * 1024 * 1024),
+  getUsedMemory: jest.fn(async () => 4 * 1024 * 1024 * 1024),
+  getSystemName: jest.fn(() => 'Android'),
+  getSystemVersion: jest.fn(() => '17'),
+  isEmulator: jest.fn(async () => false),
+  getDeviceId: jest.fn(() => 'pixel10'),
+}));
+
+describe('Pixel 10 image generation CPU path integration', () => {
+  beforeEach(() => {
+    Platform.OS = 'android';
+    (hardwareService as any).cachedDeviceInfo = null;
+    (hardwareService as any).cachedSoCInfo = null;
+    (hardwareService as any).cachedImageRecommendation = null;
+    (hardwareService as any).cachedOpenCLCapability = null;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Platform.OS = originalOS;
+  });
+
+  it('detects Pixel 10 and disables OpenCL image acceleration', async () => {
+    expect(hardwareService.requiresCpuImageBackend()).toBe(true);
+    const openCl = await hardwareService.getOpenCLCapability();
+    expect(openCl.supported).toBe(false);
+    expect(openCl.reason).toBe('pixel_10_cpu_only');
+  });
+
+  it('recommends only MNN models with a Pixel 10-specific banner', async () => {
+    const rec = await hardwareService.getImageModelRecommendation();
+    expect(rec.recommendedBackend).toBe('mnn');
+    expect(rec.compatibleBackends).toEqual(['mnn']);
+    expect(rec.bannerText).toContain('Pixel 10');
+    expect(DeviceInfo.getModel).toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/services/hardware.test.ts
+++ b/__tests__/unit/services/hardware.test.ts
@@ -18,6 +18,7 @@ describe('HardwareService', () => {
     (hardwareService as any).cachedDeviceInfo = null;
     (hardwareService as any).cachedSoCInfo = null;
     (hardwareService as any).cachedImageRecommendation = null;
+    (hardwareService as any).cachedOpenCLCapability = null;
   });
 
   // ========================================================================
@@ -1013,7 +1014,7 @@ describe('HardwareService', () => {
         });
         const rec = await hardwareService.getImageModelRecommendation();
         expect(rec.recommendedBackend).toBe('mnn');
-        expect(rec.bannerText).toContain('GPU');
+        expect(rec.bannerText).toContain('MNN');
         expect(rec.bannerText).toContain('888');
         expect(rec.compatibleBackends).toEqual(['mnn']);
       });
@@ -1027,6 +1028,26 @@ describe('HardwareService', () => {
         });
         const rec = await hardwareService.getImageModelRecommendation();
         expect(rec.recommendedBackend).toBe('mnn');
+        expect(rec.bannerText).toContain('MNN');
+        expect(rec.bannerText).toContain('Tensor');
+      });
+
+      it('recommends MNN with Pixel 10 CPU notice', async () => {
+        await setupDevice({
+          totalGB: 12,
+          platform: 'android',
+          hardware: 'tensor',
+          model: 'Pixel 10 Pro XL',
+        });
+        const rec = await hardwareService.getImageModelRecommendation();
+        expect(rec.recommendedBackend).toBe('mnn');
+        expect(rec.compatibleBackends).toEqual(['mnn']);
+        expect(rec.bannerText).toContain('Pixel 10');
+        expect(hardwareService.requiresCpuImageBackend()).toBe(true);
+        expect(await hardwareService.getOpenCLCapability()).toEqual({
+          supported: false,
+          reason: 'pixel_10_cpu_only',
+        });
       });
     });
 
@@ -1051,7 +1072,7 @@ describe('HardwareService', () => {
 
         const rec = await hardwareService.getImageModelRecommendation();
         expect(rec.recommendedBackend).toBe('mnn');
-        expect(rec.bannerText).toContain('GPU');
+        expect(rec.bannerText).toContain('MNN');
         expect(rec.compatibleBackends).toEqual(['mnn']);
       });
     });

--- a/__tests__/unit/services/huggingFaceModelBrowser.test.ts
+++ b/__tests__/unit/services/huggingFaceModelBrowser.test.ts
@@ -55,7 +55,7 @@ describe('huggingFaceModelBrowser', () => {
   // parseFileName (tested indirectly via fetchAvailableModels)
   // -----------------------------------------------------------------------
   describe('parseFileName (via fetchAvailableModels)', () => {
-    it('parses MNN backend zip as a GPU model', async () => {
+    it('parses MNN backend zip as an MNN model', async () => {
       mockFetchResponses(
         { ok: true, body: [treeEntry('AnythingV5.zip', 500, 'file', 2000)] },
         { ok: true, body: [] },
@@ -67,7 +67,7 @@ describe('huggingFaceModelBrowser', () => {
       expect(models[0]).toMatchObject({
         id: 'anythingv5_cpu',
         name: 'AnythingV5',
-        displayName: 'Anything V5 (GPU)',
+        displayName: 'Anything V5 (MNN)',
         backend: 'mnn',
         fileName: 'AnythingV5.zip',
         size: 2000,

--- a/src/screens/DownloadManagerScreen/useDownloadManager.ts
+++ b/src/screens/DownloadManagerScreen/useDownloadManager.ts
@@ -58,7 +58,7 @@ function getActiveItemFileName(
 function getImageAuthor(backend?: string): string {
   if (backend === 'coreml') return 'Core ML';
   if (backend === 'qnn') return 'NPU';
-  if (backend === 'mnn') return 'GPU';
+  if (backend === 'mnn') return 'MNN';
   return 'Image Generation';
 }
 

--- a/src/screens/ModelsScreen/ImageFilterBar.tsx
+++ b/src/screens/ModelsScreen/ImageFilterBar.tsx
@@ -18,10 +18,12 @@ interface Props {
   hasActiveImageFilters: boolean;
   clearImageFilters: () => void;
   setUserChangedBackendFilter: (v: boolean) => void;
+  /** When false, hide the NPU filter chip (device has no QNN catalog entries). */
+  npuAvailable?: boolean;
 }
 
 function getBackendLabel(filter: BackendFilter): string {
-  if (filter === 'mnn') return 'GPU';
+  if (filter === 'mnn') return 'MNN';
   if (filter === 'qnn') return 'NPU';
   if (filter === 'coreml') return 'Core ML';
   return 'Backend';
@@ -45,12 +47,13 @@ interface ExpandedSectionProps {
   setStyleFilter: (f: string) => void;
   setImageFilterExpanded: (d: ImageFilterDimension | ((prev: ImageFilterDimension) => ImageFilterDimension)) => void;
   setUserChangedBackendFilter: (v: boolean) => void;
+  backendOptions: { key: BackendFilter; label: string }[];
 }
 
 const FilterExpandedSection: React.FC<ExpandedSectionProps> = ({
   imageFilterExpanded, backendFilter, sdVersionFilter, styleFilter,
   setBackendFilter, setSdVersionFilter, setStyleFilter,
-  setImageFilterExpanded, setUserChangedBackendFilter,
+  setImageFilterExpanded, setUserChangedBackendFilter, backendOptions,
 }) => {
   const styles = useThemedStyles(createStyles);
 
@@ -58,7 +61,7 @@ const FilterExpandedSection: React.FC<ExpandedSectionProps> = ({
     return (
       <View style={styles.filterExpandedContent}>
         <View style={styles.filterChipWrap}>
-          {BACKEND_OPTIONS.map(option => (
+          {backendOptions.map(option => (
             <TouchableOpacity
               key={option.key}
               style={[styles.filterChip, backendFilter === option.key && styles.filterChipActive]}
@@ -118,8 +121,12 @@ export const ImageFilterBar: React.FC<Props> = ({
   imageFilterExpanded, setImageFilterExpanded,
   hasActiveImageFilters, clearImageFilters,
   setUserChangedBackendFilter,
+  npuAvailable = true,
 }) => {
   const styles = useThemedStyles(createStyles);
+  const backendOptions = npuAvailable
+    ? BACKEND_OPTIONS
+    : BACKEND_OPTIONS.filter(o => o.key !== 'qnn');
 
   const backendLabel = getBackendLabel(backendFilter);
   const sdLabel = getSdLabel(sdVersionFilter);
@@ -175,6 +182,7 @@ export const ImageFilterBar: React.FC<Props> = ({
         setStyleFilter={setStyleFilter}
         setImageFilterExpanded={setImageFilterExpanded}
         setUserChangedBackendFilter={setUserChangedBackendFilter}
+        backendOptions={backendOptions}
       />
     </View>
   );

--- a/src/screens/ModelsScreen/ImageModelsTab.tsx
+++ b/src/screens/ModelsScreen/ImageModelsTab.tsx
@@ -28,7 +28,7 @@ type Props = Pick<ModelsScreenViewModel,
   | 'hasActiveImageFilters'
   | 'showRecommendedOnly' | 'setShowRecommendedOnly'
   | 'showRecHint' | 'setShowRecHint'
-  | 'imageRec' | 'ramGB' | 'imageRecommendation'
+  | 'imageRec' | 'ramGB' | 'imageRecommendation' | 'imageNpuAvailable'
   | 'handleDownloadImageModel' | 'handleCancelImageDownload' | 'loadHFModels'
   | 'clearImageFilters' | 'setUserChangedBackendFilter'
   | 'isRecommendedModel'
@@ -133,11 +133,12 @@ interface ScrollContentProps {
   handleDownloadImageModel: Props['handleDownloadImageModel'];
   handleCancelImageDownload: Props['handleCancelImageDownload'];
   imageSearchQuery: string;
+  imageNpuAvailable: boolean;
 }
 
 const ImageModelsScrollContent: React.FC<ScrollContentProps> = ({
   showRecHint, showRecommendedOnly, setShowRecHint,
-  imageRec, ramGB, imageRecommendation,
+  imageRec, ramGB, imageRecommendation, imageNpuAvailable,
   imageFiltersVisible, backendFilter, setBackendFilter,
   styleFilter, setStyleFilter, sdVersionFilter, setSdVersionFilter,
   imageFilterExpanded, setImageFilterExpanded,
@@ -202,6 +203,7 @@ const ImageModelsScrollContent: React.FC<ScrollContentProps> = ({
             hasActiveImageFilters={hasActiveImageFilters}
             clearImageFilters={clearImageFilters}
             setUserChangedBackendFilter={setUserChangedBackendFilter}
+            npuAvailable={imageNpuAvailable}
           />
         )}
 
@@ -262,7 +264,7 @@ export const ImageModelsTab: React.FC<Props> = ({
   hasActiveImageFilters,
   showRecommendedOnly, setShowRecommendedOnly,
   showRecHint, setShowRecHint,
-  imageRec, ramGB, imageRecommendation,
+  imageRec, ramGB, imageRecommendation, imageNpuAvailable,
   handleDownloadImageModel, handleCancelImageDownload, loadHFModels,
   clearImageFilters, setUserChangedBackendFilter,
   isRecommendedModel,
@@ -311,6 +313,7 @@ export const ImageModelsTab: React.FC<Props> = ({
         imageRec={imageRec}
         ramGB={ramGB}
         imageRecommendation={imageRecommendation}
+        imageNpuAvailable={imageNpuAvailable}
         imageFiltersVisible={imageFiltersVisible}
         backendFilter={backendFilter}
         setBackendFilter={setBackendFilter}

--- a/src/screens/ModelsScreen/constants.ts
+++ b/src/screens/ModelsScreen/constants.ts
@@ -58,7 +58,7 @@ export const SD_VERSION_OPTIONS = [
 
 export const BACKEND_OPTIONS: { key: BackendFilter; label: string }[] = [
   { key: 'all', label: 'All' },
-  { key: 'mnn', label: 'GPU' },
+  { key: 'mnn', label: 'MNN' },
   { key: 'qnn', label: 'NPU' },
 ];
 

--- a/src/screens/ModelsScreen/imageDownloadQnn.ts
+++ b/src/screens/ModelsScreen/imageDownloadQnn.ts
@@ -9,7 +9,7 @@ export function getQnnWarningMessage(
   if (!socInfo.hasNPU) {
     return 'NPU models require a Qualcomm Snapdragon processor. ' +
       'Your device does not have a compatible NPU and this model will not work. ' +
-      'Consider downloading a CPU model instead.';
+      'Consider downloading an MNN model instead.';
   }
   if (!modelInfo.variant || !socInfo.qnnVariant) return null;
 

--- a/src/screens/ModelsScreen/useImageModels.ts
+++ b/src/screens/ModelsScreen/useImageModels.ts
@@ -28,6 +28,7 @@ export function useImageModels(setAlertState: (s: AlertState) => void) {
   const [imageSearchQuery, setImageSearchQuery] = useState('');
   const [imageFiltersVisible, setImageFiltersVisible] = useState(false);
   const [imageRec, setImageRec] = useState<ImageModelRecommendation | null>(null);
+  const [imageNpuAvailable, setImageNpuAvailable] = useState(false);
   const [userChangedBackendFilter, setUserChangedBackendFilter] = useState(false);
   const [showRecommendedOnly, setShowRecommendedOnly] = useState(true);
   const [showRecHint, setShowRecHint] = useState(true);
@@ -66,6 +67,7 @@ export function useImageModels(setAlertState: (s: AlertState) => void) {
         })));
       } else {
         const socInfo = await hardwareService.getSoCInfo();
+        setImageNpuAvailable(socInfo.hasNPU);
         setAvailableHFModels(await fetchAvailableModels(forceRefresh, { skipQnn: !socInfo.hasNPU }));
       }
     } catch (error: any) {
@@ -130,6 +132,11 @@ export function useImageModels(setAlertState: (s: AlertState) => void) {
     hardwareService.getImageModelRecommendation().then(rec => {
       if (cancelled) return;
       setImageRec(rec);
+      hardwareService.getSoCInfo().then(soc => {
+        if (cancelled) return;
+        setImageNpuAvailable(soc.hasNPU);
+        setBackendFilter(prev => (!soc.hasNPU && prev === 'qnn') ? 'mnn' : prev);
+      });
       if (!userChangedBackendFilter && Platform.OS !== 'ios') {
         let filter: 'qnn' | 'mnn' | 'all';
         if (rec.recommendedBackend === 'qnn') filter = 'qnn';
@@ -208,6 +215,7 @@ export function useImageModels(setAlertState: (s: AlertState) => void) {
     imageFiltersVisible, setImageFiltersVisible,
     imageRec, showRecommendedOnly, setShowRecommendedOnly,
     showRecHint, setShowRecHint,
+    imageNpuAvailable,
     downloadedImageModels,
     hasActiveImageFilters, filteredHFModels, imageRecommendation,
     loadHFModels, loadDownloadedImageModels,

--- a/src/screens/ModelsScreen/useModelsScreen.ts
+++ b/src/screens/ModelsScreen/useModelsScreen.ts
@@ -285,6 +285,7 @@ export function useModelsScreen() {
     imageFiltersVisible: image.imageFiltersVisible,
     setImageFiltersVisible: image.setImageFiltersVisible,
     imageRec: image.imageRec,
+    imageNpuAvailable: image.imageNpuAvailable,
     showRecommendedOnly: image.showRecommendedOnly,
     setShowRecommendedOnly: image.setShowRecommendedOnly,
     showRecHint: image.showRecHint,

--- a/src/services/activeModelService/index.ts
+++ b/src/services/activeModelService/index.ts
@@ -242,7 +242,7 @@ class ActiveModelService {
         return {
           canLoad: false,
           error:
-            'NPU models require a Qualcomm Snapdragon processor. Your device does not have a compatible NPU. Please use a GPU model instead.',
+            'NPU models require a Qualcomm Snapdragon processor. Your device does not have a compatible NPU. Please download an MNN model instead.',
         };
       }
     }
@@ -308,12 +308,13 @@ class ActiveModelService {
     }
     this.loadingState.image = true;
     this.notifyListeners();
+    const forceCpuImage = hardwareService.requiresCpuImageBackend();
     this.imageLoadPromise = doLoadImageModel({
       model,
       modelId,
       imageThreads,
       needsThreadReload,
-      cpuOnly: false,
+      cpuOnly: forceCpuImage,
       preferGpu: hardwareService.preferGpuForImageGen(),
       store,
       timeoutMs,

--- a/src/services/hardware.ts
+++ b/src/services/hardware.ts
@@ -397,14 +397,23 @@ class HardwareService {
       rec = {
         recommendedBackend: 'mnn',
         bannerText:
-          'GPU models recommended \u2014 your Snapdragon doesn\u2019t support NPU acceleration',
+          'MNN models recommended \u2014 your Snapdragon does not support NPU acceleration',
+        compatibleBackends: ['mnn'],
+      };
+    } else if (socInfo.vendor === 'tensor') {
+      rec = {
+        recommendedBackend: 'mnn',
+        bannerText:
+          this.requiresCpuImageBackend()
+            ? 'MNN models recommended for Pixel \u2014 image generation runs on CPU on Pixel 10 until GPU support lands'
+            : 'MNN models recommended for Pixel and Tensor devices',
         compatibleBackends: ['mnn'],
       };
     } else {
       rec = {
         recommendedBackend: 'mnn',
         bannerText:
-          'GPU models recommended \u2014 NPU requires Snapdragon 888+',
+          'MNN models recommended \u2014 NPU acceleration requires Snapdragon 888+',
         compatibleBackends: ['mnn'],
       };
     }
@@ -436,6 +445,9 @@ class HardwareService {
   async getOpenCLCapability(): Promise<{ supported: boolean; reason?: string }> {
     if (this.cachedOpenCLCapability) return this.cachedOpenCLCapability;
     if (Platform.OS !== 'android') return { supported: false, reason: 'not_android' };
+    if (this.requiresCpuImageBackend()) {
+      return (this.cachedOpenCLCapability = { supported: false, reason: 'pixel_10_cpu_only' });
+    }
     try {
       const hardware = (await DeviceInfo.getHardware()).toLowerCase();
       // Support Qualcomm Adreno (qcom) and ARM Mali GPUs.
@@ -444,6 +456,15 @@ class HardwareService {
       if (!hasCompatibleGpu) return (this.cachedOpenCLCapability = { supported: false, reason: 'no_compatible_gpu' });
       return (this.cachedOpenCLCapability = { supported: true });
     } catch { return (this.cachedOpenCLCapability = { supported: false, reason: 'detection_failed' }); }
+  }
+
+  /**
+   * Pixel 10 OpenCL/GPU image backends are broken on-device (same class of bug as
+   * LiteRT GPU on Pixel 10). Force the MNN CPU path for image load + generation.
+   */
+  requiresCpuImageBackend(): boolean {
+    if (Platform.OS !== 'android') return false;
+    return DeviceInfo.getModel().toLowerCase().includes('pixel 10');
   }
 }
 export const hardwareService = new HardwareService();

--- a/src/services/huggingFaceModelBrowser.ts
+++ b/src/services/huggingFaceModelBrowser.ts
@@ -59,11 +59,12 @@ function parseFileName(fileName: string, backend: 'mnn' | 'qnn'): Omit<HFImageMo
     };
   }
 
-  // GPU: e.g. "AnythingV5.zip"
+  // MNN: CPU/GPU via OpenCL — label as MNN so users on Pixel/Tensor are not told
+  // to pick a separate "CPU model" while the catalog only lists "GPU" and "NPU".
   return {
     id: `${baseName.toLowerCase()}_cpu`,
     name: baseName,
-    displayName: `${insertSpaces(baseName)} (GPU)`,
+    displayName: `${insertSpaces(baseName)} (MNN)`,
     backend: 'mnn',
     fileName,
   };

--- a/src/services/imageGenerationService.ts
+++ b/src/services/imageGenerationService.ts
@@ -8,6 +8,7 @@ import logger from '../utils/logger';
 import { shouldShowSharePrompt, emitSharePrompt } from '../utils/sharePrompt';
 import { checkProPromptForImage } from '../utils/proPrompt';
 import { buildEnhancementMessages, getConversationContext, cleanEnhancedPrompt, buildImageGenMeta } from './imageGenerationHelpers';
+import { hardwareService } from './hardware';
 import { reportModelFailure } from './modelFailureHandler';
 import { reasonFromLoadError } from './modelFailureReasons';
 
@@ -454,7 +455,10 @@ class ImageGenerationService {
     if (!loaded) return null;
     if (this.cancelRequested) { this.resetState(); return null; }
 
-    return this._runGenerationAndSave({ params, enhancedPrompt, activeImageModel, steps, guidanceScale, imageWidth, imageHeight, useOpenCL: settings.imageUseOpenCL ?? true });
+    const useOpenCL = hardwareService.requiresCpuImageBackend()
+      ? false
+      : (settings.imageUseOpenCL ?? true);
+    return this._runGenerationAndSave({ params, enhancedPrompt, activeImageModel, steps, guidanceScale, imageWidth, imageHeight, useOpenCL });
   }
 
   async cancelGeneration(): Promise<void> {


### PR DESCRIPTION
## Summary

- Force MNN CPU image load and generation on Pixel 10 (OpenCL/GPU path is broken on-device).
- Rename MNN model labels from GPU to MNN across catalog, filters, and Download Manager.
- Add Tensor-specific image recommendation banner for Pixel devices.
- Hide the NPU backend filter when the device has no QNN catalog entries.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #432

## Test plan

- [x] npx jest __tests__/integration/models/pixel10ImageGenCpuPath.test.ts
- [x] npx jest __tests__/unit/services/hardware.test.ts (Pixel/Tensor/MNN cases)
- [x] npx jest __tests__/unit/services/huggingFaceModelBrowser.test.ts (MNN labeling)
- [ ] Manual on Pixel 10 XL: Image Models tab shows MNN models, NPU filter hidden, generation completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device-aware image generation support for Pixel 10 devices, automatically routing them to the appropriate backend.
  * Improved model browsing and download labels to show clearer backend names, including MNN.

* **Bug Fixes**
  * Fixed image generation backend selection when a device lacks NPU support.
  * Updated recommendations and warnings to guide users toward compatible models more accurately.
  * Refined filter options so unavailable backends are hidden when not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->