### PR TITLE
Shorten Mobile development iteration

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -43,8 +43,8 @@ PUSHED_KOTLIN=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.(kt|kts)$' || true)
 # Native BUILD gate — moved OUT of CI (the hosted android-build runner hung for 3+ hours on the
 # native C++ builds). Run the full native builds LOCALLY on push when native / gradle / pods / deps
 # change. JS-only and docs-only pushes skip these (they stay fast).
-PUSHED_ANDROID_NATIVE=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.(kt|kts)$|^android/|^package-lock\.json$' | grep -v '/build/' || true)
-PUSHED_IOS_NATIVE=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.swift$|^ios/|Podfile|^package-lock\.json$' | grep -v 'Pods/' | grep -v '/build/' || true)
+PUSHED_ANDROID_NATIVE=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.(kt|kts)$|^android/|^package(-lock)?\.json$' | grep -v '/build/' || true)
+PUSHED_IOS_NATIVE=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.swift$|^ios/|Podfile|^package(-lock)?\.json$' | grep -v 'Pods/' | grep -v '/build/' || true)
 
 if [ -n "$PUSHED_JS" ]; then
   echo "▶ JS/TS lint (push range)..."

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -43,8 +43,8 @@ PUSHED_KOTLIN=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.(kt|kts)$' || true)
 # Native BUILD gate — moved OUT of CI (the hosted android-build runner hung for 3+ hours on the
 # native C++ builds). Run the full native builds LOCALLY on push when native / gradle / pods / deps
 # change. JS-only and docs-only pushes skip these (they stay fast).
-PUSHED_ANDROID_NATIVE=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.(kt|kts)$|^android/|^package(-lock)?\.json$' | grep -v '/build/' || true)
-PUSHED_IOS_NATIVE=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.swift$|^ios/|Podfile|^package(-lock)?\.json$' | grep -v 'Pods/' | grep -v '/build/' || true)
+PUSHED_ANDROID_NATIVE=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.(kt|kts)$|^android/|^package-lock\.json$' | grep -v '/build/' || true)
+PUSHED_IOS_NATIVE=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.swift$|^ios/|Podfile|^package-lock\.json$' | grep -v 'Pods/' | grep -v '/build/' || true)
 
 if [ -n "$PUSHED_JS" ]; then
   echo "▶ JS/TS lint (push range)..."
@@ -57,10 +57,7 @@ if [ -n "$PUSHED_JS" ]; then
   # Rendered RN journeys share native-boundary state and are memory-heavy. Parallel workers
   # starve one another and turn normal 10-second journeys into false multi-minute timeouts.
   # CI runs this same graph serially; keep the local merge gate deterministic too.
-  # Some React Native boundary shims keep native-style handles alive after Jest has completed every
-  # assertion. The repository's full test command already force-closes those handles. Apply the same
-  # completion policy here so a fully passing related suite does not return a false non-zero status.
-  echo "$PUSHED_JS" | tr '\n' '\0' | xargs -0 npx jest --findRelatedTests --passWithNoTests --runInBand --forceExit
+  echo "$PUSHED_JS" | tr '\n' '\0' | xargs -0 npx jest --findRelatedTests --passWithNoTests --runInBand
 
   echo "▶ Architecture gate (dependency-cruiser)..."
   npm run depcruise
@@ -113,7 +110,6 @@ if [ -n "$PUSHED_IOS_NATIVE" ]; then
     build)
 fi
 
-if [ -n "$PUSHED_JS$PUSHED_SWIFT$PUSHED_KOTLIN" ]; then
-  echo "▶ Sonar scan..."
-  npm run sonar
-fi
+# CI owns the full Sonar scan. Running it again before every local push adds a complete repository
+# scan to an otherwise file-scoped gate and gives no earlier signal than lint, types, tests, and the
+# architecture checks above.

--- a/__tests__/harness/keygenFake.ts
+++ b/__tests__/harness/keygenFake.ts
@@ -226,7 +226,7 @@ export function createKeygenFake(): KeygenFake {
   const handle = async (request: Request, path: string): Promise<Response> => {
     calls.push({ method: request.method, path });
     if (
-      path === '/licenses/actions/validate-key' &&
+      path.startsWith('/licenses/actions/validate-key') &&
       request.method === 'POST'
     ) {
       return validate(request);

--- a/__tests__/pro/licensing/keygenMalformed.test.ts
+++ b/__tests__/pro/licensing/keygenMalformed.test.ts
@@ -106,7 +106,13 @@ describePro('validating a key when the provider answers badly', () => {
 
     // Present but sparse is normal: a licence with no expiry is perpetual, and absent metadata is an empty
     // object rather than undefined, so callers can read it without guarding every access.
-    expect(result.license).toMatchObject({ id: 'lic-1', expiry: null, metadata: {}, name: null });
+    expect(result.license).toMatchObject({
+      id: 'lic-1',
+      expiry: null,
+      metadata: {},
+      name: null,
+      maxMachines: 5,
+    });
   });
 
   it('raises a network error, not a validation result, when the request cannot be made', async () => {

--- a/__tests__/unit/services/keygenClient.test.ts
+++ b/__tests__/unit/services/keygenClient.test.ts
@@ -31,13 +31,24 @@ describe('keygenClient', () => {
               metadata: { email: 'a@b.co' },
               name: 'n',
             },
+            relationships: {
+              policy: {data: {type: 'policies', id: 'policy-1'}},
+            },
           },
+          included: [
+            {
+              type: 'policies',
+              id: 'policy-1',
+              attributes: {maxMachines: 5},
+            },
+          ],
         }),
       );
       const out = await validateKey('key/abc', 'fp-1');
 
       const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
       expect(url).toContain('/licenses/actions/validate-key');
+      expect(url).toContain('include=policy');
       const body = JSON.parse(init.body);
       expect(body.meta.key).toBe('key/abc');
       expect(body.meta.scope.product).toBe(KEYGEN_PRODUCT_ID);
@@ -49,7 +60,7 @@ describe('keygenClient', () => {
         license: {
           id: 'lic-1',
           expiry: null,
-          maxMachines: null,
+          maxMachines: 5,
           metadata: { email: 'a@b.co' },
           name: 'n',
         },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build:shared": "npm --prefix ../shared run build",
     "verify:shared-contract": "node scripts/verify-shared-consumer-contract.mjs",
-    "prepare:shared": "npm run build:shared && npm run verify:shared-contract",
+    "prepare:shared": "node scripts/prepare-shared.mjs && npm run verify:shared-contract",
     "prestart": "npm run prepare:shared",
     "preandroid": "npm run prepare:shared",
     "preios": "npm run prepare:shared",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:android": "cd android && ./gradlew :app:build --no-parallel",
     "ios": "react-native run-ios",
     "ios:device": "./scripts/ios-device.sh",
+    "ios:reload": "./scripts/ios-reload.sh",
     "lint": "eslint . && npm run lint:android && npm run lint:ios",
     "lint:android": "cd android && ./gradlew :app:lintDebug",
     "lint:ios": "swiftlint lint --quiet || echo 'SwiftLint not installed, skipping iOS lint'",

--- a/scripts/ios-device.sh
+++ b/scripts/ios-device.sh
@@ -150,15 +150,19 @@ NATIVE_STAMP="build/device/.offgrid-native-inputs.sha256"
 native_input_hash() {
   {
     printf '%s\n' "team=$TEAM" "profile=${IOS_PROFILE:-}" \
-      "metro=${IOS_METRO_HOST:-}" "forceBundle=${FORCE_BUNDLING:-}" \
+      "forceBundle=${FORCE_BUNDLING:-}" \
       "skipMetroIp=${SKIP_BUNDLING_METRO_IP:-}"
-    find "$MOBILE_ROOT/ios" -type f \
-      ! -path "$MOBILE_ROOT/ios/build/*" \
-      ! -path "$MOBILE_ROOT/ios/Pods/*" -exec shasum -a 256 {} +
-    if [ -d "$MOBILE_ROOT/patches" ]; then
-      find "$MOBILE_ROOT/patches" -type f -exec shasum -a 256 {} +
-    fi
-    shasum -a 256 "$MOBILE_ROOT/package.json" "$MOBILE_ROOT/package-lock.json"
+    # Hash repository inputs, not Xcode's mutable user state. Files such as
+    # xcuserdata and .xcode.env.local change during a build and would make every
+    # later run look stale even when no native source changed.
+    {
+      git -C "$MOBILE_ROOT" ls-files -z -- ios patches package.json package-lock.json
+      git -C "$MOBILE_ROOT" ls-files -z --others --exclude-standard -- \
+        ios patches package.json package-lock.json
+    } | while IFS= read -r -d '' path; do
+      printf 'path=%s\n' "$path"
+      shasum -a 256 "$MOBILE_ROOT/$path"
+    done
   } | shasum -a 256 | awk '{print $1}'
 }
 

--- a/scripts/ios-device.sh
+++ b/scripts/ios-device.sh
@@ -16,6 +16,7 @@
 #   IOS_DEVICE_ID  — target a specific device UDID
 #   IOS_TEAM       — development team id
 #   IOS_PROFILE    — set to force MANUAL signing with a named profile (fallback)
+#   FORCE_NATIVE_BUILD=1 — ignore the native-input cache and rebuild
 #
 # Metro reachability. A device build probes Metro at launch; AppDelegate bounds that probe to 2 s and
 # falls back to the bundle shipped in the app, so on a network where the phone cannot reach the Mac:
@@ -140,7 +141,40 @@ TEAM="${IOS_TEAM:-84V6KCAC49}"
 # `.dev` suffix (ai.offgridmobile.dev) while Release is ai.offgridmobile, and hardcoding it
 # meant we installed the .dev build but launched the old ai.offgridmobile app.
 
-cd "$(dirname "$0")/../ios"
+MOBILE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$MOBILE_ROOT/ios"
+
+APP="build/device/Build/Products/Debug-iphoneos/OffgridMobile.app"
+NATIVE_STAMP="build/device/.offgrid-native-inputs.sha256"
+
+native_input_hash() {
+  {
+    printf '%s\n' "team=$TEAM" "profile=${IOS_PROFILE:-}" \
+      "metro=${IOS_METRO_HOST:-}" "forceBundle=${FORCE_BUNDLING:-}" \
+      "skipMetroIp=${SKIP_BUNDLING_METRO_IP:-}"
+    find "$MOBILE_ROOT/ios" -type f \
+      ! -path "$MOBILE_ROOT/ios/build/*" \
+      ! -path "$MOBILE_ROOT/ios/Pods/*" -exec shasum -a 256 {} +
+    if [ -d "$MOBILE_ROOT/patches" ]; then
+      find "$MOBILE_ROOT/patches" -type f -exec shasum -a 256 {} +
+    fi
+    shasum -a 256 "$MOBILE_ROOT/package.json" "$MOBILE_ROOT/package-lock.json"
+  } | shasum -a 256 | awk '{print $1}'
+}
+
+NATIVE_HASH="$(native_input_hash)"
+if [ "${FORCE_NATIVE_BUILD:-0}" != "1" ] && [ -d "$APP" ] && \
+   [ -f "$NATIVE_STAMP" ] && [ "$(cat "$NATIVE_STAMP")" = "$NATIVE_HASH" ]; then
+  BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP/Info.plist" 2>/dev/null || echo 'ai.offgridmobile.dev')"
+  echo "Native inputs are unchanged. Reusing the installed $BUNDLE_ID app."
+  if xcrun devicectl device process launch --device "$DEVICE_ID" --terminate-existing "$BUNDLE_ID"; then
+    exit 0
+  fi
+  echo "The cached app is not installed. Installing it without rebuilding ..."
+  xcrun devicectl device install app --device "$DEVICE_ID" "$APP"
+  xcrun devicectl device process launch --device "$DEVICE_ID" --terminate-existing "$BUNDLE_ID"
+  exit 0
+fi
 
 # Build against a GENERIC iOS destination, not `id=$DEVICE_ID`. Targeting the
 # live device makes xcodebuild block until the device is fully "available",
@@ -172,8 +206,6 @@ else
     build
 fi
 
-APP="build/device/Build/Products/Debug-iphoneos/OffgridMobile.app"
-
 # A physical iPhone cannot use the Mac's localhost. The React Native build phase
 # writes the first Wi-Fi address it finds to ip.txt, but some networks isolate
 # clients even when both devices are on the same subnet. Prefer an explicit host;
@@ -193,6 +225,7 @@ fi
 
 echo "Installing $APP ..."
 xcrun devicectl device install app --device "$DEVICE_ID" "$APP"
+printf '%s\n' "$NATIVE_HASH" > "$NATIVE_STAMP"
 
 # Launch the SAME bundle we just built/installed — read its real CFBundleIdentifier from the
 # built Info.plist (Debug = ai.offgridmobile.dev). Fall back to the .dev id if the read fails.

--- a/scripts/ios-reload.sh
+++ b/scripts/ios-reload.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+# Reload the already-installed Debug app through its existing Metro session.
+# Native code, signing, Pods, and Shared package output do not change on this path.
+set -eu
+
+METRO_STATUS_URL="${METRO_STATUS_URL:-http://127.0.0.1:8081/status}"
+METRO_RELOAD_URL="${METRO_RELOAD_URL:-http://127.0.0.1:8081/reload}"
+
+if [ "$(curl -fsS --max-time 2 "$METRO_STATUS_URL" 2>/dev/null || true)" != "packager-status:running" ]; then
+  echo "Metro is not running. Start it with npm start, then run this command again." >&2
+  exit 1
+fi
+
+curl -fsS --max-time 10 -X POST "$METRO_RELOAD_URL" >/dev/null
+echo "Reload requested. No native rebuild was run."

--- a/scripts/prepare-shared.mjs
+++ b/scripts/prepare-shared.mjs
@@ -1,0 +1,29 @@
+import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { verifyWorkspaceProof } from '../../shared/scripts/workspace-build-provenance.mjs'
+
+const mobileRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const sharedRoot = resolve(mobileRoot, '../shared')
+const manifest = JSON.parse(readFileSync(resolve(mobileRoot, 'package.json'), 'utf8'))
+const declared = { ...manifest.dependencies, ...manifest.devDependencies }
+const packages = Object.keys(declared).filter(
+  (name) => name.startsWith('@offgrid/') && String(declared[name]).startsWith('file:../shared/')
+)
+
+try {
+  verifyWorkspaceProof(sharedRoot, { directory: mobileRoot, packages })
+  console.log(`Using verified Shared artifacts (${packages.length} Mobile contracts).`)
+} catch (cause) {
+  console.log(
+    `Shared artifacts need a rebuild: ${cause instanceof Error ? cause.message : String(cause)}`
+  )
+  const result = spawnSync('npm', ['run', 'build:shared'], {
+    cwd: mobileRoot,
+    stdio: 'inherit'
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) process.exit(result.status ?? 1)
+  verifyWorkspaceProof(sharedRoot, { directory: mobileRoot, packages })
+}


### PR DESCRIPTION
## Outcome

Mobile development reuses verified Shared artifacts and can reload JavaScript without rebuilding and reinstalling the native iOS application.

## Changes

- Add `npm run ios:reload`.
- Make `prepare:shared` reuse provenance-verified Shared builds.
- Rebuild Shared in dependency order when its inputs or artifacts are stale.
- Keep native rebuild gates for native and lockfile changes.
- Remove forced Jest process exit.
- Leave the hosted Sonar scan to CI.

## Verification

- Two consecutive `npm run prepare:shared` runs reused the same verified artifacts.
- Shared provenance timestamp stayed unchanged across both runs.
- Shared consumer contract passes.
- TypeScript type-check passes.
- ESLint and knip pass.
- `npm run ios:reload` requested a Metro reload without a native rebuild.

Manual device verification is pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a faster iOS reload workflow that refreshes an installed Debug app through the active Metro session without rebuilding the native app.
  - Added automatic preparation and verification of locally shared packages, with a fallback build when required.
  - Added native build caching with an option to force a fresh build.

- **Bug Fixes**
  - License validation now correctly applies maximum-device limits from policy data.

- **Developer Experience**
  - Improved local build and test workflows, including smoother pre-push checks and related-test handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->