### PR TITLE
fix(sync): revoke Mobile Pro access on eviction

### DIFF
--- a/__tests__/unit/licensing/proLicenseProvider.test.ts
+++ b/__tests__/unit/licensing/proLicenseProvider.test.ts
@@ -908,6 +908,34 @@ describe('the licence this phone holds', () => {
       });
     });
 
+    it('locks Pro before protected storage finishes clearing', async () => {
+      const provider = load();
+      provider.setDirectEntitlementActivationOwner(activationOwner().owner);
+      await provider.proLicenseProvider.activate!(LICENCE_KEY);
+      let finishClear: (() => void) | undefined;
+      keychain().resetGenericPassword.mockImplementation(
+        () =>
+          new Promise<boolean>(resolve => {
+            finishClear = () => resolve(true);
+          }),
+      );
+
+      const clearing = provider.clearProAfterRemoteMembershipRevocation();
+      const { useAppStore } =
+        require('../../../src/stores/appStore') as typeof import('../../../src/stores/appStore');
+      const { selectHasProAccess } =
+        require('../../../src/stores/proAccessSlice') as typeof import('../../../src/stores/proAccessSlice');
+
+      expect(useAppStore.getState().proDeviceAdmission).toBe('inactive');
+      expect(selectHasProAccess(useAppStore.getState())).toBe(false);
+
+      finishClear?.();
+      await clearing;
+      keychain().resetGenericPassword.mockImplementation(
+        async ({ service }: { service: string }) => secrets.delete(service),
+      );
+    });
+
     it('can be reset for testing without leaving anything behind', async () => {
       const provider = load();
       provider.setDirectEntitlementActivationOwner(activationOwner().owner);


### PR DESCRIPTION
## Summary
- consume the shared Personal Mesh device-cap contract
- clear Mobile Pro access immediately after authenticated remote eviction
- cover the reactive entitlement transition

## Verification
- focused entitlement checks passed
- fresh iOS device build succeeded
- live Desktop-to-iPhone eviction removed Mobile Pro access immediately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pro access is now locked immediately when remote membership revocation is processed, without waiting for credential cleanup to finish.

- **Tests**
  - Added coverage confirming that Pro access remains unavailable while revocation cleanup is still pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->