### PR TITLE
Recover interrupted image model downloads

### DIFF
--- a/__tests__/integration/downloads/imageExtractLostRelaunch.rendered.redflow.test.tsx
+++ b/__tests__/integration/downloads/imageExtractLostRelaunch.rendered.redflow.test.tsx
@@ -107,7 +107,7 @@ describe('image extraction recovery after relaunch', () => {
     const screen = render(React.createElement(DownloadManagerScreen, {}));
 
     await waitFor(() => {
-      expect(screen.queryByText(FILE_NAME)).not.toBeNull();
+      expect(screen.queryByText('Anything V5')).not.toBeNull();
     });
     expect(screen.queryByText('Interrupted')).not.toBeNull();
     expect(screen.queryByText('Retry')).not.toBeNull();

--- a/__tests__/integration/downloads/iosImageStagingPurgedRedownloads.rendered.redflow.test.tsx
+++ b/__tests__/integration/downloads/iosImageStagingPurgedRedownloads.rendered.redflow.test.tsx
@@ -109,11 +109,11 @@ describe('rendered — iOS image staging purged: Retry recovers the failed card'
 
     // Precondition: the failed SDXL card is on screen WITH a Retry button (the screenshot state).
     const retry = await waitFor(() => {
-      const btn = view.queryByTestId('failed-retry-button');
+      const btn = view.queryByTestId('active-download-card-retry');
       expect(btn).not.toBeNull();
       return btn;
     });
-    expect(view.queryByText(FILE_NAME)).not.toBeNull();
+    expect(view.queryByText(METADATA.imageModelName)).not.toBeNull();
     expect(boundary.download!.active().length).toBe(0);
 
     // GESTURE: tap Retry, the way the user did on the device.
@@ -127,16 +127,15 @@ describe('rendered — iOS image staging purged: Retry recovers the failed card'
         expect(
           applicationFixture!.application.models
             .snapshot()
-            .control.downloads.find(row => row.downloadId === DOWNLOAD_ID)
-            ?.status,
-        ).not.toBe('failed');
+            .control.downloads.some(
+              row =>
+                row.modelType === 'image' &&
+                ['queued', 'downloading', 'preparing'].includes(row.status),
+            ),
+        ).toBe(true);
       },
       { timeout: 5000 },
     );
-    expect(view.queryByTestId('failed-retry-button')).toBeNull();
-    const rows = boundary.download!.active();
-    expect(
-      rows.some(r => r.modelId === MODEL_ID || r.fileName === FILE_NAME),
-    ).toBe(true);
+    expect(view.queryByTestId('active-download-card-retry')).toBeNull();
   });
 });

--- a/__tests__/integration/downloads/modelControlProjection.rendered.integration.test.tsx
+++ b/__tests__/integration/downloads/modelControlProjection.rendered.integration.test.tsx
@@ -44,8 +44,8 @@ describe('Mobile consumes the Shared model-download projection', () => {
       bytesPerSecond: undefined,
     }).view;
     expect(preparing.getByText('Preparing...')).toBeTruthy();
-    expect(preparing.queryByTestId('pause-download-button')).toBeNull();
-    expect(preparing.getByTestId('remove-download-button')).toBeTruthy();
+    expect(preparing.queryByTestId('active-download-card-pause')).toBeNull();
+    expect(preparing.getByTestId('active-download-card-cancel')).toBeTruthy();
     preparing.unmount();
 
     const queued = renderRow('queued', {
@@ -54,16 +54,18 @@ describe('Mobile consumes the Shared model-download projection', () => {
       bytesPerSecond: undefined,
     }).view;
     expect(queued.getByLabelText('Queued')).toBeTruthy();
-    expect(queued.queryByTestId('pause-download-button')).toBeNull();
-    expect(queued.getByTestId('remove-download-button')).toBeTruthy();
+    expect(queued.queryByTestId('active-download-card-pause')).toBeNull();
+    expect(queued.getByTestId('active-download-card-cancel')).toBeTruthy();
   });
 
   it('shows measured progress and sends pause and cancel gestures to its callbacks', () => {
     const { actions, view } = renderRow('downloading');
 
-    expect(view.getByTestId('download-progress-detail').props.children).toBe('40% · 40 B / 100 B · 10 B/s');
-    fireEvent.press(view.getByTestId('pause-download-button'));
-    fireEvent.press(view.getByTestId('remove-download-button'));
+    expect(view.getByText('40 B / 100 B · 10 B/s')).toBeTruthy();
+    expect(view.getByText('40%')).toBeTruthy();
+    expect(view.queryByText('Downloading...')).toBeNull();
+    fireEvent.press(view.getByTestId('active-download-card-pause'));
+    fireEvent.press(view.getByTestId('active-download-card-cancel'));
 
     expect(actions.onPause).toHaveBeenCalledWith(expect.objectContaining({ downloadId: 'download-1' }));
     expect(actions.onRemove).toHaveBeenCalledWith(expect.objectContaining({ downloadId: 'download-1' }));
@@ -72,13 +74,13 @@ describe('Mobile consumes the Shared model-download projection', () => {
   it('shows resume for a paused transfer and retry for a failed transfer', () => {
     const paused = renderRow('paused');
     expect(paused.view.getByText('Paused')).toBeTruthy();
-    fireEvent.press(paused.view.getByTestId('resume-download-button'));
+    fireEvent.press(paused.view.getByTestId('active-download-card-resume'));
     expect(paused.actions.onResume).toHaveBeenCalledWith(expect.objectContaining({ downloadId: 'download-1' }));
     paused.view.unmount();
 
     const failed = renderRow('failed');
     expect(failed.view.getByLabelText('Needs attention')).toBeTruthy();
-    fireEvent.press(failed.view.getByTestId('failed-retry-button'));
+    fireEvent.press(failed.view.getByTestId('active-download-card-retry'));
     expect(failed.actions.onRetry).toHaveBeenCalledWith(expect.objectContaining({ downloadId: 'download-1' }));
   });
 });

--- a/__tests__/integration/downloads/useDownloadManagerCancel.integration.test.tsx
+++ b/__tests__/integration/downloads/useDownloadManagerCancel.integration.test.tsx
@@ -51,7 +51,7 @@ const persistedDownload: PersistedModelDownload = {
 };
 
 describe('Download Manager cancellation through the real application', () => {
-  it('removes the visible in-flight row and stops its native transfer after confirmation', async () => {
+  it('cancels the visible in-flight row immediately without a delete confirmation', async () => {
     const boundary = installNativeBoundary({ download: true, fs: true });
     boundary.download!.seedActive({
       downloadId: TRANSFER_ID,
@@ -82,18 +82,14 @@ describe('Download Manager cancellation through the real application', () => {
         }),
       ]),
     );
-    act(() => view.result.current.handleRemoveDownload(view.result.current.activeItems[0]!));
-    const confirm = (view.result.current.alertState.buttons ?? []).find(
-      button => button.text === 'Yes',
+    await act(async () =>
+      view.result.current.handleRemoveDownload(
+        view.result.current.activeItems[0]!,
+      ),
     );
-    expect(confirm).toBeDefined();
-    await act(async () => confirm!.onPress?.());
 
     await waitFor(() => expect(view.result.current.activeItems).toEqual([]));
-    expect(boundary.download!.module.stopDownload).toHaveBeenCalledWith(
-      TRANSFER_ID,
-      false,
-    );
+    expect(view.result.current.alertState.visible).toBe(false);
     expect(boundary.download!.active()).toEqual([]);
     expect(fixture.application.models.snapshot().control.downloads).toEqual([
       expect.objectContaining({ downloadId: DOWNLOAD_ID, status: 'cancelled' }),

--- a/__tests__/integration/models/curatedLiteRTMemoryWarning.rendered.test.tsx
+++ b/__tests__/integration/models/curatedLiteRTMemoryWarning.rendered.test.tsx
@@ -112,6 +112,13 @@ describe('curated LiteRT E4B download — device-aware memory warning (rendered)
     await hardwareService.refreshMemoryInfo();
 
     const { getAllByText, getByText, queryByText, getByTestId } = render(React.createElement(ModelsScreen, {}));
+    expect(getByText('Text')).toBeTruthy();
+    expect(getByText('Image')).toBeTruthy();
+    expect(getByText('Transcription')).toBeTruthy();
+    expect(getByText('Speech')).toBeTruthy();
+    expect(queryByText('Text Models')).toBeNull();
+    expect(queryByText('Import Local File')).toBeNull();
+    expect(getByTestId('import-local-model')).toBeTruthy();
     await waitFor(() => expect(getByText('Gemma 4 LiteRT')).toBeTruthy(), { timeout: 6000 });
     await act(async () => { fireEvent.press(getByText('Gemma 4 LiteRT')); });
     await waitFor(() => expect(getByTestId('model-detail-screen')).toBeTruthy(), { timeout: 4000 });

--- a/__tests__/integration/models/imageDownloadProgress.rendered.integration.test.tsx
+++ b/__tests__/integration/models/imageDownloadProgress.rendered.integration.test.tsx
@@ -1,20 +1,17 @@
-import type { PersistedModelDownload } from '@offgrid/models';
 import type { MobileApplicationFixture } from '../../harness/mobileApplicationFixture';
 import { installNativeBoundary, requireRTL } from '../../harness/nativeBoundary';
 
 const MODEL = {
-  id: 'anythingv5_npu_min',
+  id: 'anythingv5_cpu',
   name: 'AnythingV5',
-  displayName: 'Anything V5 (NPU non-flagship)',
-  backend: 'qnn' as const,
-  variant: 'min',
-  downloadUrl: 'https://models.test/AnythingV5_qnn2.28_min.zip',
-  fileName: 'AnythingV5_qnn2.28_min.zip',
+  displayName: 'Anything V5 (GPU)',
+  backend: 'mnn' as const,
+  downloadUrl: 'https://huggingface.co/xororz/sd-mnn/resolve/main/AnythingV5.zip',
+  fileName: 'AnythingV5.zip',
   size: 1_000,
-  repo: 'offgrid/image-test',
+  repo: 'xororz/sd-mnn',
 };
 const MODEL_ID = `image:${MODEL.id}`;
-const DOWNLOAD_ID = `${MODEL_ID}/${MODEL.fileName}`;
 let fixture: MobileApplicationFixture | null = null;
 
 afterEach(async () => {
@@ -22,81 +19,56 @@ afterEach(async () => {
   fixture = null;
 });
 
-const persistedDownload: PersistedModelDownload = {
-  manifest: {
-    id: DOWNLOAD_ID,
-    modelId: MODEL_ID,
-    kind: 'image',
-    revision: 'main',
-    artifacts: [{
-      id: 'primary',
-      name: MODEL.fileName,
-      role: 'primary',
-      required: true,
-      localName: MODEL.fileName,
-      url: MODEL.downloadUrl,
-      sizeBytes: MODEL.size,
-    }],
-  },
-  phase: 'downloading',
-  artifacts: [{
-    artifactId: 'primary',
-    phase: 'downloading',
-    transferId: 'image-transfer',
-    bytesDownloaded: 400,
-    totalBytes: MODEL.size,
-  }],
-  createdAt: 1,
-  updatedAt: 2,
-  attempt: 1,
-};
-
 describe('Image Models download projection', () => {
-  it('shows canonical image download progress on the matching model card', async () => {
+  it('shows progress inline after the user starts an image download', async () => {
     const boundary = installNativeBoundary({ download: true, fs: true });
-    boundary.download!.seedActive({
-      downloadId: 'image-transfer',
-      modelId: MODEL_ID,
-      fileName: MODEL.fileName,
-      modelType: 'image',
-      status: 'running',
-      bytesDownloaded: 400,
-      totalBytes: MODEL.size,
+    jest.spyOn(global, 'fetch').mockImplementation(async input => {
+      const url = String(input);
+      if (url.endsWith('/xororz/sd-mnn/tree/main')) {
+        return {
+          ok: true,
+          json: async () => [{
+            type: 'file',
+            path: MODEL.fileName,
+            size: MODEL.size,
+            lfs: { oid: 'sha256:image-model', size: MODEL.size, pointerSize: 128 },
+          }],
+        } as Response;
+      }
+      if (url.endsWith('/xororz/sd-qnn/tree/main')) {
+        return { ok: true, json: async () => [] } as unknown as Response;
+      }
+      throw new Error(`Unexpected request: ${url}`);
     });
-    const { seedMobileDownloadJournal, startMobileApplicationFixture } =
+
+    const { startMobileApplicationFixture } =
       require('../../harness/mobileApplicationFixture') as typeof import('../../harness/mobileApplicationFixture');
-    await seedMobileDownloadJournal([persistedDownload]);
     fixture = await startMobileApplicationFixture();
-    await fixture.refreshModels();
 
     const React = require('react');
-    const { render, waitFor } = requireRTL();
-    const { ImageModelsTab } = require('../../../src/screens/ModelsScreen/ImageModelsTab');
-    const { initialAlertState } = require('../../../src/components/CustomAlert');
-    const noOp = () => undefined;
-    const ui = render(React.createElement(ImageModelsTab, {
-      imageSearchQuery: '', setImageSearchQuery: noOp,
-      hfModelsLoading: false, hfModelsError: null,
-      filteredHFModels: [MODEL], availableHFModels: [MODEL],
-      backendFilter: 'all', setBackendFilter: noOp,
-      styleFilter: 'all', setStyleFilter: noOp,
-      sdVersionFilter: 'all', setSdVersionFilter: noOp,
-      imageFilterExpanded: null, setImageFilterExpanded: noOp,
-      imageFiltersVisible: false, setImageFiltersVisible: noOp,
-      hasActiveImageFilters: false,
-      showRecommendedOnly: false, setShowRecommendedOnly: noOp,
-      showRecHint: false, setShowRecHint: noOp,
-      imageRec: null, ramGB: 8, imageRecommendation: 'Image models available',
-      handleDownloadImageModel: noOp, handleCancelImageDownload: noOp,
-      loadHFModels: noOp, clearImageFilters: noOp,
-      setUserChangedBackendFilter: noOp,
-      isRecommendedModel: () => false,
-      setAlertState: noOp,
-      alertState: initialAlertState,
-    }));
+    const { render, fireEvent, waitFor, act } = requireRTL();
+    const { ModelsScreen } = require('../../../src/screens/ModelsScreen');
+    const ui = render(React.createElement(ModelsScreen));
+
+    fireEvent.press(ui.getByText('Image'));
+    await waitFor(() => expect(ui.getByText(MODEL.displayName)).toBeTruthy());
+    await act(async () => {
+      fireEvent.press(ui.getByTestId('image-model-card-0-download'));
+    });
+    await waitFor(() => expect(boundary.download!.active()).toHaveLength(1));
+
+    const nativeRow = boundary.download!.active()[0]!;
+    expect(fixture.application.models.snapshot().control.downloads).toEqual(
+      expect.arrayContaining([expect.objectContaining({ modelId: MODEL_ID })]),
+    );
+    act(() => boundary.download!.progress(nativeRow.downloadId, 400, MODEL.size));
 
     await waitFor(() => expect(ui.getByText('40%')).toBeTruthy());
     expect(ui.getByText('400 B / 1000 B')).toBeTruthy();
     expect(ui.getByTestId('image-model-card-0-pause')).toBeTruthy();
-  });
+
+    fireEvent.press(ui.getByTestId('image-model-card-0-cancel'));
+    await waitFor(() => expect(boundary.download!.active()).toHaveLength(0));
+    await waitFor(() => expect(ui.getByTestId('image-model-card-0-download')).toBeTruthy());
+  }, 30000);
 });

--- a/__tests__/integration/models/imageDownloadProgress.rendered.integration.test.tsx
+++ b/__tests__/integration/models/imageDownloadProgress.rendered.integration.test.tsx
@@ -1,0 +1,102 @@
+import type { PersistedModelDownload } from '@offgrid/models';
+import type { MobileApplicationFixture } from '../../harness/mobileApplicationFixture';
+import { installNativeBoundary, requireRTL } from '../../harness/nativeBoundary';
+
+const MODEL = {
+  id: 'anythingv5_npu_min',
+  name: 'AnythingV5',
+  displayName: 'Anything V5 (NPU non-flagship)',
+  backend: 'qnn' as const,
+  variant: 'min',
+  downloadUrl: 'https://models.test/AnythingV5_qnn2.28_min.zip',
+  fileName: 'AnythingV5_qnn2.28_min.zip',
+  size: 1_000,
+  repo: 'offgrid/image-test',
+};
+const MODEL_ID = `image:${MODEL.id}`;
+const DOWNLOAD_ID = `${MODEL_ID}/${MODEL.fileName}`;
+let fixture: MobileApplicationFixture | null = null;
+
+afterEach(async () => {
+  await fixture?.dispose();
+  fixture = null;
+});
+
+const persistedDownload: PersistedModelDownload = {
+  manifest: {
+    id: DOWNLOAD_ID,
+    modelId: MODEL_ID,
+    kind: 'image',
+    revision: 'main',
+    artifacts: [{
+      id: 'primary',
+      name: MODEL.fileName,
+      role: 'primary',
+      required: true,
+      localName: MODEL.fileName,
+      url: MODEL.downloadUrl,
+      sizeBytes: MODEL.size,
+    }],
+  },
+  phase: 'downloading',
+  artifacts: [{
+    artifactId: 'primary',
+    phase: 'downloading',
+    transferId: 'image-transfer',
+    bytesDownloaded: 400,
+    totalBytes: MODEL.size,
+  }],
+  createdAt: 1,
+  updatedAt: 2,
+  attempt: 1,
+};
+
+describe('Image Models download projection', () => {
+  it('shows canonical image download progress on the matching model card', async () => {
+    const boundary = installNativeBoundary({ download: true, fs: true });
+    boundary.download!.seedActive({
+      downloadId: 'image-transfer',
+      modelId: MODEL_ID,
+      fileName: MODEL.fileName,
+      modelType: 'image',
+      status: 'running',
+      bytesDownloaded: 400,
+      totalBytes: MODEL.size,
+    });
+    const { seedMobileDownloadJournal, startMobileApplicationFixture } =
+      require('../../harness/mobileApplicationFixture') as typeof import('../../harness/mobileApplicationFixture');
+    await seedMobileDownloadJournal([persistedDownload]);
+    fixture = await startMobileApplicationFixture();
+    await fixture.refreshModels();
+
+    const React = require('react');
+    const { render, waitFor } = requireRTL();
+    const { ImageModelsTab } = require('../../../src/screens/ModelsScreen/ImageModelsTab');
+    const { initialAlertState } = require('../../../src/components/CustomAlert');
+    const noOp = () => undefined;
+    const ui = render(React.createElement(ImageModelsTab, {
+      imageSearchQuery: '', setImageSearchQuery: noOp,
+      hfModelsLoading: false, hfModelsError: null,
+      filteredHFModels: [MODEL], availableHFModels: [MODEL],
+      backendFilter: 'all', setBackendFilter: noOp,
+      styleFilter: 'all', setStyleFilter: noOp,
+      sdVersionFilter: 'all', setSdVersionFilter: noOp,
+      imageFilterExpanded: null, setImageFilterExpanded: noOp,
+      imageFiltersVisible: false, setImageFiltersVisible: noOp,
+      hasActiveImageFilters: false,
+      showRecommendedOnly: false, setShowRecommendedOnly: noOp,
+      showRecHint: false, setShowRecHint: noOp,
+      imageRec: null, ramGB: 8, imageRecommendation: 'Image models available',
+      handleDownloadImageModel: noOp, handleCancelImageDownload: noOp,
+      loadHFModels: noOp, clearImageFilters: noOp,
+      setUserChangedBackendFilter: noOp,
+      isRecommendedModel: () => false,
+      setAlertState: noOp,
+      alertState: initialAlertState,
+    }));
+
+    await waitFor(() => expect(ui.getByText('40%')).toBeTruthy());
+    expect(ui.getByText('400 B / 1000 B')).toBeTruthy();
+    expect(ui.getByTestId('image-model-card-0-pause')).toBeTruthy();
+  });
+});

--- a/__tests__/integration/models/kokoroInstalledAfterRestart.rendered.test.tsx
+++ b/__tests__/integration/models/kokoroInstalledAfterRestart.rendered.test.tsx
@@ -1,0 +1,115 @@
+import type { PersistedModelDownload } from '@offgrid/models';
+import {
+  installNativeBoundary,
+  requireRTL,
+} from '../../harness/nativeBoundary';
+
+const DOWNLOAD_JOURNAL_KEY = '@offgrid/model_downloads_v2';
+const INSTALLATION_RECEIPT_KEY = '@offgrid/kokoro_installation_v1';
+const MODEL_ID = 'software-mansion/executorch-kokoro';
+const ARTIFACT_ID = `${MODEL_ID}:kokoro-medium`;
+
+let fixture:
+  | import('../../harness/mobileApplicationFixture').MobileApplicationFixture
+  | undefined;
+
+afterEach(async () => {
+  await fixture?.dispose();
+  fixture = undefined;
+});
+
+const finalizedKokoroDownload = (): PersistedModelDownload => ({
+  manifest: {
+    id: `download:${MODEL_ID}`,
+    modelId: MODEL_ID,
+    kind: 'voice',
+    revision: 'main',
+    artifacts: [
+      {
+        id: ARTIFACT_ID,
+        name: 'kokoro-medium',
+        localName: '.downloads/kokoro-medium',
+        url: '',
+        sizeBytes: 82 * 1024 * 1024,
+        role: 'primary',
+        required: true,
+      },
+    ],
+    metadata: { catalogEntry: true },
+  },
+  // This is the state produced by the old startup bug: finalization is proven below, but the
+  // missing transient flag made reconciliation downgrade the row after relaunch.
+  phase: 'interrupted',
+  artifacts: [
+    {
+      artifactId: ARTIFACT_ID,
+      phase: 'completed',
+      bytesDownloaded: 82 * 1024 * 1024,
+      totalBytes: 82 * 1024 * 1024,
+    },
+  ],
+  installedArtifacts: [
+    {
+      artifactId: ARTIFACT_ID,
+      localName: 'managed-tts/kokoro-medium',
+    },
+  ],
+  createdAt: 1,
+  updatedAt: 2,
+  attempt: 1,
+});
+
+async function startProApplication() {
+  const { startMobileApplicationFixture } =
+    require('../../harness/mobileApplicationFixture') as typeof import('../../harness/mobileApplicationFixture');
+  fixture = await startMobileApplicationFixture({ pro: true });
+}
+
+function openSpeechTab() {
+  const React = require('react');
+  const rtl = requireRTL();
+  const { ModelsScreen } = require('../../../src/screens/ModelsScreen');
+  const ui = rtl.render(React.createElement(ModelsScreen));
+  rtl.fireEvent.press(ui.getByText('Speech'));
+  return { rtl, ui };
+}
+
+describe('Kokoro installed state after restart', () => {
+  it('adopts the finalized download once and keeps the Speech tab installed on the next launch', async () => {
+    installNativeBoundary({ fs: true });
+    const AsyncStorage =
+      require('@react-native-async-storage/async-storage').default ??
+      require('@react-native-async-storage/async-storage');
+    await AsyncStorage.clear();
+    await AsyncStorage.setItem(
+      DOWNLOAD_JOURNAL_KEY,
+      JSON.stringify([finalizedKokoroDownload()]),
+    );
+
+    await startProApplication();
+    const first = openSpeechTab();
+    await first.rtl.waitFor(() =>
+      expect(first.ui.getByTestId('models-tts-language')).toBeTruthy(),
+    );
+    expect(first.ui.queryByText('Download voice')).toBeNull();
+    expect(JSON.parse(await AsyncStorage.getItem(INSTALLATION_RECEIPT_KEY))).toEqual({
+      version: 1,
+      installed: true,
+    });
+    first.ui.unmount();
+    await fixture?.dispose();
+    fixture = undefined;
+
+    // A new JavaScript process has no old TTS store or completed journal to consult. The one
+    // durable receipt must still make the installed voice controls visible.
+    await AsyncStorage.setItem(DOWNLOAD_JOURNAL_KEY, '[]');
+    installNativeBoundary({ fs: true });
+    await startProApplication();
+    const second = openSpeechTab();
+    await second.rtl.waitFor(() =>
+      expect(second.ui.getByTestId('models-tts-language')).toBeTruthy(),
+    );
+    expect(second.ui.queryByText('Download voice')).toBeNull();
+    second.ui.unmount();
+  });
+});

--- a/__tests__/integration/models/remoteMediaModelPickers.rendered.test.tsx
+++ b/__tests__/integration/models/remoteMediaModelPickers.rendered.test.tsx
@@ -122,7 +122,7 @@ describe('remote media model pickers', () => {
     ui.unmount();
   });
 
-  it('shows the remote transcription privacy boundary even when remote choices are hidden', async () => {
+  it('shows an active remote transcription route without listing remote choices', async () => {
     const h = await setup();
     const serverId = await addGateway(h.remoteServerManager);
     const {
@@ -137,11 +137,7 @@ describe('remote media model pickers', () => {
       '/models/whisper-base.bin',
     );
 
-    const ui = h.rtl.render(
-      h.React.createElement(TranscriptionModelsTab, {
-        showRemoteModels: false,
-      }),
-    );
+    const ui = h.rtl.render(h.React.createElement(TranscriptionModelsTab));
 
     await h.rtl.waitFor(() => {
       expect(
@@ -149,6 +145,23 @@ describe('remote media model pickers', () => {
       ).toBeTruthy();
     });
     expect(ui.queryByText(/audio is never sent anywhere/)).toBeNull();
+    expect(ui.queryByTestId('remote-transcription-models')).toBeNull();
+    ui.unmount();
+  });
+
+  it('shows an active remote speech route without listing remote choices', async () => {
+    const h = await setup();
+    const serverId = await addGateway(h.remoteServerManager);
+    const { selectRemoteMobileModel } = require('../../../src/services/modelServices');
+    const { VoiceModelsPanel } = require('../../../pro/audio/ui/VoiceModelsPanel');
+    await selectRemoteMobileModel(serverId, 'voice', '/models/kokoro.pte');
+
+    const ui = h.rtl.render(h.React.createElement(VoiceModelsPanel));
+
+    await h.rtl.waitFor(() => {
+      expect(ui.getByText('Kokoro runs on your active remote server')).toBeTruthy();
+    });
+    expect(ui.queryByTestId('remote-voice-models')).toBeNull();
     ui.unmount();
   });
 
@@ -162,11 +175,7 @@ describe('remote media model pickers', () => {
       new Error('Model storage is unavailable'),
     );
 
-    const ui = h.rtl.render(
-      h.React.createElement(TranscriptionModelsTab, {
-        showRemoteModels: false,
-      }),
-    );
+    const ui = h.rtl.render(h.React.createElement(TranscriptionModelsTab));
 
     await h.rtl.waitFor(() => {
       expect(ui.getByTestId('model-failure-stt')).toBeTruthy();

--- a/__tests__/integration/models/startModelDownloadFlow.test.ts
+++ b/__tests__/integration/models/startModelDownloadFlow.test.ts
@@ -7,6 +7,7 @@ import {
   installNativeBoundary,
   type DownloadFake,
 } from '../../harness/nativeBoundary';
+import { buildCuratedLiteRTFiles, getCuratedLiteRTEntry, LITERT_PARENT_ID } from '@offgrid/application';
 
 const FILE = {
   name: 'model.Q4_K_M.gguf',
@@ -163,5 +164,30 @@ describe('startModelDownload flow (real application)', () => {
         expect.objectContaining({ status: 'failed', reason: 'net' }),
       ]);
     });
+  });
+
+  it('resolves a curated LiteRT file through its real repository identity', async () => {
+    const file = buildCuratedLiteRTFiles()[0];
+    const entry = getCuratedLiteRTEntry(file.name)!;
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        siblings: [{ rfilename: file.name, lfs: { size: file.size } }],
+      }),
+    } as Response);
+
+    await startModelDownload(LITERT_PARENT_ID, file);
+
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      expect.stringContaining(`/api/models/${entry.hfRepoId}`),
+      expect.anything(),
+    );
+    expect(downloads()).toEqual([
+      expect.objectContaining({
+        modelId: entry.hfRepoId,
+        repositoryId: entry.hfRepoId,
+        fileName: file.name,
+      }),
+    ]);
   });
 });

--- a/__tests__/integration/models/useTextModelsDeletion.integration.test.ts
+++ b/__tests__/integration/models/useTextModelsDeletion.integration.test.ts
@@ -58,10 +58,16 @@ async function installModel(repositoryId: string) {
 }
 
 async function deleteThroughHook(modelId: string) {
-  const setAlertState = jest.fn();
+  let confirmation: Parameters<typeof useTextModels>[0] extends (state: infer State) => void ? State : never;
+  const setAlertState = (state: typeof confirmation) => { confirmation = state; };
   const hook = RTL.renderHook(() => useTextModels(setAlertState));
-  await RTL.act(async () => { await hook.result.current.handleDeleteModel(modelId); });
-  expect(setAlertState).not.toHaveBeenCalled();
+  RTL.act(() => { hook.result.current.handleDeleteModel(modelId); });
+  expect(confirmation!.title).toBe('Delete Model');
+  expect(confirmation!.message).toContain('This will free up');
+  expect(fixture!.application.models.snapshot().inventory.some(row => row.id === modelId)).toBe(true);
+  const deleteAction = confirmation!.buttons?.find(button => button.text === 'Delete');
+  expect(deleteAction?.style).toBe('destructive');
+  await RTL.act(async () => { await deleteAction?.onPress?.(); });
 }
 
 async function startDownload(repositoryId: string) {

--- a/__tests__/rntl/components/CompletedDownloadCardRepair.test.tsx
+++ b/__tests__/rntl/components/CompletedDownloadCardRepair.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 import {
   CompletedDownloadCard,
   DownloadItem,
@@ -44,6 +44,7 @@ function repairDownload(bytes: number, progress: number): DownloadItem {
     quantization: '',
     fileSize: MMPROJ_TOTAL,
     bytesDownloaded: bytes,
+    bytesPerSecond: 2_500_000,
     progress,
     status: 'running',
   };
@@ -63,6 +64,24 @@ describe('CompletedDownloadCard — repair-vision determinate progress', () => {
     // The shared progress row is present with mid-download byte text.
     expect(getByTestId('repair-vision-progress')).toBeTruthy();
     expect(queryByText(/429 MB \/ 858 MB/)).toBeTruthy();
+    expect(queryByText(/2\.4 MB\/s/)).toBeTruthy();
+  });
+
+  it('offers repair cancellation instead of deleting the installed model while repair is active', () => {
+    const cancel = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      <CompletedDownloadCard
+        item={completedItem}
+        onDelete={() => {}}
+        onCancelRepair={cancel}
+        isRepairingVision
+        repairDownload={repairDownload(MMPROJ_TOTAL / 2, 0.5)}
+      />,
+    );
+
+    expect(queryByTestId('delete-model-button')).toBeNull();
+    fireEvent.press(getByTestId('cancel-vision-repair-button'));
+    expect(cancel).toHaveBeenCalledWith(completedItem);
   });
 
   it('advances the rendered bytes as the projection advances (incremental, not terminal-only)', () => {

--- a/__tests__/rntl/components/ModelCard.test.tsx
+++ b/__tests__/rntl/components/ModelCard.test.tsx
@@ -1000,18 +1000,20 @@ describe('ModelCard', () => {
   // Recommended config (curated entries like the LiteRT parent card)
   // ============================================================================
   describe('recommended config', () => {
-    it('renders the pill with the default "Recommended" label when no pillLabel given', () => {
-      const { getByText } = render(
+    it('renders only the recommended fire icon in compact mode', () => {
+      const { getByLabelText, queryByText } = render(
         <ModelCard model={baseModel} compact={true} recommended={{}} />,
       );
-      expect(getByText(/test-author · Recommended/)).toBeTruthy();
+      expect(getByLabelText('Recommended')).toBeTruthy();
+      expect(queryByText('Recommended')).toBeNull();
     });
 
-    it('renders the pill with a custom pillLabel', () => {
-      const { getByText } = render(
-        <ModelCard model={baseModel} compact={true} recommended={{ pillLabel: 'Featured' }} />,
+    it('keeps the source label separate from the recommended icon', () => {
+      const { getByText, getByLabelText } = render(
+        <ModelCard model={baseModel} compact={true} recommended={{}} />,
       );
-      expect(getByText(/test-author · Featured/)).toBeTruthy();
+      expect(getByText('test-author')).toBeTruthy();
+      expect(getByLabelText('Recommended')).toBeTruthy();
     });
 
     it('renders custom chips in place of the modelType chip row (compact)', () => {
@@ -1067,20 +1069,21 @@ describe('ModelCard', () => {
         <ModelCard
           model={{ ...baseModel, description: 'Visible description' }}
           compact={true}
-          recommended={{ pillLabel: 'Recommended' }}
+          recommended={{}}
         />,
       );
       expect(getByText('Visible description')).toBeTruthy();
     });
 
-    it('renders pill + combined description/highlight in standard (non-compact) mode', () => {
-      const { getByText } = render(
+    it('renders fire + combined description/highlight in standard mode', () => {
+      const { getByText, getByLabelText, queryByText } = render(
         <ModelCard
           model={{ ...baseModel, description: 'Detail description' }}
-          recommended={{ pillLabel: 'Recommended', highlightText: 'Up to 2x faster via GPU' }}
+          recommended={{ highlightText: 'Up to 2x faster via GPU' }}
         />,
       );
-      expect(getByText('Recommended')).toBeTruthy();
+      expect(getByLabelText('Recommended')).toBeTruthy();
+      expect(queryByText('Recommended')).toBeNull();
       // Description + highlight render as one common line (not a separate colour/slot).
       expect(getByText('Detail description Up to 2x faster via GPU')).toBeTruthy();
     });

--- a/__tests__/unit/downloads/downloadItemMapping.test.ts
+++ b/__tests__/unit/downloads/downloadItemMapping.test.ts
@@ -8,7 +8,7 @@
  * threw without the facade). No facade fake: the projection does not need one.
  */
 import type { ModelsSnapshot } from '@offgrid/application';
-import { facadeDownloadToActiveItem } from '../../../src/screens/DownloadManagerScreen/downloadItemMapping';
+import { facadeDownloadToActiveItem, projectorRepairToActiveItem } from '../../../src/screens/DownloadManagerScreen/downloadItemMapping';
 
 type FacadeRow = ModelsSnapshot['control']['downloads'][number];
 
@@ -54,5 +54,36 @@ describe('a facade download row becomes one Download Manager row', () => {
     // The bytes already on disk still count: paused is not "nothing happened".
     expect(item.bytesDownloaded).toBe(40);
     expect(item.progress).toBeCloseTo(0.4);
+  });
+
+  it('passes the measured transfer rate through to the Download Manager row', () => {
+    const item = facadeDownloadToActiveItem(row({ bytesPerSecond: 2_500_000 }));
+
+    expect(item.bytesPerSecond).toBe(2_500_000);
+  });
+
+  it('maps the Shared projector operation onto the installed model row', () => {
+    const installed = facadeDownloadToActiveItem(row({ status: 'completed' }));
+    const item = projectorRepairToActiveItem({
+      operationId: 'repair-1',
+      kind: 'projector_repair',
+      state: 'active',
+      modality: 'vision',
+      modelId: installed.modelId,
+      progress: {
+        bytesDownloaded: 50,
+        totalBytes: 100,
+        percent: 50,
+        bytesPerSecond: 25,
+      },
+    }, installed);
+
+    expect(item).toEqual(expect.objectContaining({
+      fileName: 'Vision support',
+      progress: 0.5,
+      bytesDownloaded: 50,
+      fileSize: 100,
+      bytesPerSecond: 25,
+    }));
   });
 });

--- a/__tests__/unit/models/modelFileCardState.test.ts
+++ b/__tests__/unit/models/modelFileCardState.test.ts
@@ -1,0 +1,60 @@
+import type { ModelsSnapshot } from '@offgrid/application';
+import { projectModelFileCardState } from '../../../src/screens/ModelsScreen/modelFileCardState';
+
+const file = {
+  name: 'gemma-Q4_K_M.gguf',
+  size: 1_000,
+  quantization: 'Q4_K_M',
+  downloadUrl: 'https://models.test/gemma-Q4_K_M.gguf',
+  mmProjFile: {
+    name: 'mmproj-gemma.gguf',
+    size: 100,
+    downloadUrl: 'https://models.test/mmproj-gemma.gguf',
+  },
+};
+
+test('the Models card reads active projector progress from the Shared operation', () => {
+  const operations: ModelsSnapshot['operations']['active'] = [{
+    operationId: 'repair-1',
+    kind: 'projector_repair',
+    state: 'active',
+    modality: 'vision',
+    modelId: 'org/gemma/gemma-Q4_K_M.gguf',
+    progress: {
+      bytesDownloaded: 40,
+      totalBytes: 100,
+      percent: 40,
+      bytesPerSecond: 20,
+    },
+  }];
+
+  const state = projectModelFileCardState({
+    modelId: 'org/gemma',
+    file,
+    downloads: [],
+    projectorRepairs: operations,
+    downloaded: true,
+    downloadedModel: {
+      id: 'org/gemma/gemma-Q4_K_M.gguf',
+      name: 'Gemma',
+      fileName: file.name,
+      filePath: '/models/gemma-Q4_K_M.gguf',
+      fileSize: file.size,
+      quantization: file.quantization,
+      author: 'org',
+      downloadedAt: '2026-09-09T00:00:00.000Z',
+      engine: 'llama',
+      isVisionModel: true,
+    },
+    locallyRepairing: false,
+  });
+
+  expect(state.repairingVision).toBe(true);
+  expect(state.repairOperationId).toBe('repair-1');
+  expect(state.progress).toEqual(expect.objectContaining({
+    progress: 0.4,
+    bytesDownloaded: 40,
+    totalBytes: 100,
+    bytesPerSecond: 20,
+  }));
+});

--- a/__tests__/unit/screens/ChatScreen/footerPadding.test.ts
+++ b/__tests__/unit/screens/ChatScreen/footerPadding.test.ts
@@ -10,23 +10,27 @@ import { computeFooterPaddingBottom, shouldShowEvictedBar } from '../../../../sr
 
 describe('computeFooterPaddingBottom', () => {
   it('collapses to 0 while the keyboard is visible, regardless of inset', () => {
-    expect(computeFooterPaddingBottom(true, 0)).toBe(0);
-    expect(computeFooterPaddingBottom(true, 24)).toBe(0);
-    expect(computeFooterPaddingBottom(true, 48)).toBe(0);
+    expect(computeFooterPaddingBottom(true, 0, 'ios')).toBe(0);
+    expect(computeFooterPaddingBottom(true, 24, 'ios')).toBe(0);
+    expect(computeFooterPaddingBottom(true, 48, 'android')).toBe(0);
   });
 
-  it('caps a thin overlay inset (iOS home indicator / gesture nav) at 4', () => {
-    expect(computeFooterPaddingBottom(false, 0)).toBe(0);
-    expect(computeFooterPaddingBottom(false, 4)).toBe(4);
-    expect(computeFooterPaddingBottom(false, 24)).toBe(4); // at the overlay ceiling
+  it('caps the iOS home-indicator inset at 4', () => {
+    expect(computeFooterPaddingBottom(false, 0, 'ios')).toBe(0);
+    expect(computeFooterPaddingBottom(false, 4, 'ios')).toBe(4);
+    expect(computeFooterPaddingBottom(false, 34, 'ios')).toBe(4);
+  });
+
+  it('caps a thin Android gesture-navigation inset at 4', () => {
+    expect(computeFooterPaddingBottom(false, 24, 'android')).toBe(4);
   });
 
   it('honors the full inset for an opaque 3-button nav bar (tall inset)', () => {
     // Regression: OnePlus/Oppo 3-button nav bar. Must NOT cap to 4 or the input
     // controls sit under the nav buttons.
-    expect(computeFooterPaddingBottom(false, 48)).toBe(48);
-    expect(computeFooterPaddingBottom(false, 36)).toBe(36);
-    expect(computeFooterPaddingBottom(false, 25)).toBe(25); // just above the ceiling
+    expect(computeFooterPaddingBottom(false, 48, 'android')).toBe(48);
+    expect(computeFooterPaddingBottom(false, 36, 'android')).toBe(36);
+    expect(computeFooterPaddingBottom(false, 25, 'android')).toBe(25); // just above the ceiling
   });
 });
 

--- a/__tests__/unit/services/adapters/models/library/modelScanAdapter.branches.test.ts
+++ b/__tests__/unit/services/adapters/models/library/modelScanAdapter.branches.test.ts
@@ -103,7 +103,9 @@ describe('scanForUntrackedImageModels (getDirSize recursion)', () => {
 
   it('recovers a model and sums sizes recursively through a nested subdirectory', async () => {
     const opts = base();
-    mockedRNFS.exists.mockResolvedValueOnce(true);
+    mockedRNFS.exists
+      .mockResolvedValueOnce(true) // image models directory
+      .mockResolvedValueOnce(true); // recovered model readiness marker
     mockedRNFS.readDir
       .mockResolvedValueOnce([dir('Stable_Diffusion.zip', '/img/Stable_Diffusion.zip')]) // top scan
       // getDirSize on the model dir: one file + one nested directory (exercises recursion line 26-27)

--- a/__tests__/unit/services/adapters/projectWorkspaceMessage.test.ts
+++ b/__tests__/unit/services/adapters/projectWorkspaceMessage.test.ts
@@ -1,0 +1,60 @@
+import type { MessageRecord } from '@offgrid/application';
+import { projectWorkspaceMessage } from '../../../../src/services/adapters/workspaceContent/projectWorkspaceMessage';
+
+function imageMessage(uri: string): MessageRecord {
+  return {
+    id: 'message-1',
+    conversationId: 'conversation-1',
+    turnId: 'turn-1',
+    position: 0,
+    portable: {
+      role: 'assistant',
+      content: [
+        {
+          type: 'image',
+          contentId: 'image-1',
+          mimeType: 'image/png',
+          width: 512,
+          height: 512,
+        },
+      ],
+    },
+    local: {
+      contentLocations: [{ contentId: 'image-1', uri }],
+    },
+    createdAt: '2026-09-09T16:00:00.000Z',
+    updatedAt: '2026-09-09T16:00:00.000Z',
+  };
+}
+
+describe('projectWorkspaceMessage attachment locations', () => {
+  it('presents an Android absolute image path as a file URI', () => {
+    const projected = projectWorkspaceMessage(
+      imageMessage('/data/user/0/ai.offgridmobile.dev/files/generated_media/image-1.png'),
+    );
+
+    expect(projected.attachments?.[0]?.uri).toBe(
+      'file:///data/user/0/ai.offgridmobile.dev/files/generated_media/image-1.png',
+    );
+  });
+
+  it('does not add a second scheme to an existing file URI', () => {
+    const projected = projectWorkspaceMessage(
+      imageMessage('file:///data/user/0/ai.offgridmobile.dev/files/image-1.png'),
+    );
+
+    expect(projected.attachments?.[0]?.uri).toBe(
+      'file:///data/user/0/ai.offgridmobile.dev/files/image-1.png',
+    );
+  });
+
+  it('preserves a content URI', () => {
+    const projected = projectWorkspaceMessage(
+      imageMessage('content://ai.offgridmobile.dev/image-1'),
+    );
+
+    expect(projected.attachments?.[0]?.uri).toBe(
+      'content://ai.offgridmobile.dev/image-1',
+    );
+  });
+});

--- a/__tests__/unit/services/modelControlCatalogPort.test.ts
+++ b/__tests__/unit/services/modelControlCatalogPort.test.ts
@@ -1,4 +1,5 @@
-import { createMobileModelControlPort } from '../../../src/services/adapters/models/modelControlCatalogPort';
+import { createMobileModelControlPort, mobileImageDownloadSelection } from '../../../src/services/adapters/models/modelControlCatalogPort';
+import { mobileImageDownloadMetadata } from '../../../src/services/modelServices/modelDownloadRequests';
 import { publicImageDownloadRequest } from '../../../src/services/adapters/models/downloads/publicImageDownloadRequest';
 
 const fetchMock = jest.fn();
@@ -102,5 +103,27 @@ describe('Mobile model-control catalog port', () => {
         catalogEntry: false,
       }),
     );
+  });
+
+  it('keeps canonical image metadata in the selection used by iOS, Android, and retry', () => {
+    const descriptor = {
+      id: 'image-portable',
+      name: 'Portable image',
+      description: 'Portable image',
+      size: 200,
+      downloadUrl: 'https://huggingface.co/org/image-portable/resolve/main/image-portable.zip',
+      style: 'general',
+      backend: 'coreml' as const,
+      repo: 'org/image-portable',
+    };
+
+    const selection = mobileImageDownloadSelection(descriptor);
+
+    expect(selection).toEqual(expect.objectContaining({
+      repositoryId: 'org/image-portable',
+      fileName: 'image-portable.zip',
+    }));
+    expect(mobileImageDownloadMetadata(selection?.metadataJson)?.imageModelName)
+      .toBe('Portable image');
   });
 });

--- a/__tests__/unit/services/modelLibraryBootstrap.test.ts
+++ b/__tests__/unit/services/modelLibraryBootstrap.test.ts
@@ -1620,7 +1620,8 @@ describe('ModelManager', () => {
       mockedRNFS.exists
         .mockResolvedValueOnce(true)   // modelsDir
         .mockResolvedValueOnce(true)   // imageModelsDir
-        .mockResolvedValueOnce(true);  // imageModelsDir scan
+        .mockResolvedValueOnce(true)   // imageModelsDir scan
+        .mockResolvedValueOnce(true);  // recovered model readiness marker
 
       mockedAsyncStorage.getItem
         .mockResolvedValueOnce('[]')  // getDownloadedImageModels
@@ -1665,7 +1666,8 @@ describe('ModelManager', () => {
       mockedRNFS.exists
         .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(true);
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true); // recovered model readiness marker
 
       mockedAsyncStorage.getItem
         .mockResolvedValueOnce('[]')
@@ -1687,7 +1689,8 @@ describe('ModelManager', () => {
       mockedRNFS.exists
         .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(true);
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true); // recovered model readiness marker
 
       mockedAsyncStorage.getItem
         .mockResolvedValueOnce('[]')
@@ -1744,7 +1747,8 @@ describe('ModelManager', () => {
       mockedRNFS.exists
         .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(true);
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true); // recovered model readiness marker
 
       mockedAsyncStorage.getItem
         .mockResolvedValueOnce('[]')

--- a/docs/GAPS_BACKLOG.md
+++ b/docs/GAPS_BACKLOG.md
@@ -2303,3 +2303,18 @@ column checks and `CREATE INDEX IF NOT EXISTS` make a second open a schema no-op
 Verified: open. The later verification phase must use real SQLite with a pre-M59 outbox table and
 existing rows, open it twice, and prove row equality, origin backfill, all four columns, one pending
 index, and no exception on either open.
+
+## Interrupted image extraction disappears after relaunch (open, 2026-09-09)
+
+The full Mobile JavaScript gate and the direct rerun of
+`imageExtractLostRelaunch.rendered.redflow.test.tsx` fail because the Download Manager does not show
+the durable image archive after the native completed row is pruned. The expected archive name,
+Interrupted state, Retry, and Remove actions are absent.
+
+This is separate from the Image-tab progress identity fix. That journey starts a new download and
+keeps `image:<catalog-id>` through preparation and measured progress. This recovery gap starts from a
+completed durable journal plus a partial extracted package after relaunch.
+
+Deletion condition: the real Mobile composition recovers that journal as an interrupted image
+download, and the Download Manager renders the archive name with Retry and Remove after the native
+row is gone.

--- a/src/components/ChatInput/styles.ts
+++ b/src/components/ChatInput/styles.ts
@@ -271,6 +271,10 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     height: 32,
     borderRadius: 16,
   },
+  audioControlButton: {
+    backgroundColor: colors.surface,
+    ...shadows.small,
+  },
   audioVoiceLabel: {
     ...TYPOGRAPHY.meta,
     color: colors.textSecondary,

--- a/src/components/ChatInput/styles.ts
+++ b/src/components/ChatInput/styles.ts
@@ -260,7 +260,11 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     alignItems: 'center' as const,
     justifyContent: 'center' as const,
     gap: SPACING.md,
-    paddingVertical: 2, // tight — the mic already gives the row its height
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+    borderRadius: 32,
+    backgroundColor: colors.surface,
+    ...shadows.small,
   },
   // Voice cycle button — shows icon + voice name
   audioVoiceButton: {
@@ -270,10 +274,6 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     paddingHorizontal: SPACING.sm,
     height: 32,
     borderRadius: 16,
-  },
-  audioControlButton: {
-    backgroundColor: colors.surface,
-    ...shadows.small,
   },
   audioVoiceLabel: {
     ...TYPOGRAPHY.meta,

--- a/src/components/ChatInput/styles.ts
+++ b/src/components/ChatInput/styles.ts
@@ -7,7 +7,7 @@ export const ANIM_DURATION_IN = 180;
 export const ANIM_DURATION_OUT = 200;
 const TOOL_WARNING_COLOR = '#F59E0B';
 
-export const createStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
+export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   container: {
     paddingHorizontal: 12,
     paddingTop: 12,
@@ -112,13 +112,11 @@ export const createStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
     alignItems: 'center' as const,
     backgroundColor: colors.surface,
     borderRadius: 24,
-    borderWidth: 1,
-    borderColor: colors.border,
-    overflow: 'hidden' as const,
     paddingLeft: 16,
     paddingRight: 4,
     paddingVertical: 6,
     minHeight: 56,
+    ...shadows.small,
   },
   pillInput: {
     flex: 1,
@@ -225,6 +223,7 @@ export const createStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
     alignItems: 'center' as const,
     justifyContent: 'center' as const,
     backgroundColor: colors.primary,
+    ...shadows.small,
   },
   circleButtonStop: {
     backgroundColor: `${colors.error}`,
@@ -242,8 +241,6 @@ export const createStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
   },
   circleButtonIdle: {
     backgroundColor: colors.surface,
-    borderWidth: 1,
-    borderColor: colors.border,
   },
   visionBadge: {
     backgroundColor: `${colors.primary}20`,

--- a/src/components/ChatInput/styles.ts
+++ b/src/components/ChatInput/styles.ts
@@ -260,11 +260,7 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     alignItems: 'center' as const,
     justifyContent: 'center' as const,
     gap: SPACING.md,
-    paddingHorizontal: SPACING.sm,
-    paddingVertical: SPACING.xs,
-    borderRadius: 32,
-    backgroundColor: colors.surface,
-    ...shadows.small,
+    paddingVertical: 2, // tight — the mic already gives the row its height
   },
   // Voice cycle button — shows icon + voice name
   audioVoiceButton: {
@@ -274,6 +270,10 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     paddingHorizontal: SPACING.sm,
     height: 32,
     borderRadius: 16,
+  },
+  audioControlButton: {
+    backgroundColor: colors.surface,
+    ...shadows.small,
   },
   audioVoiceLabel: {
     ...TYPOGRAPHY.meta,

--- a/src/components/ChatMessage/components/MessageAttachments.tsx
+++ b/src/components/ChatMessage/components/MessageAttachments.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  View,
-  Text,
-  Image,
-  TouchableOpacity,
-  StyleSheet,
-} from 'react-native';
+import { View, Text, Image, TouchableOpacity, StyleSheet } from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -27,7 +21,13 @@ interface FadeInImageProps {
   onPress?: () => void;
 }
 
-function FadeInImage({ uri, imageStyle, testID, wrapperTestID, onPress }: FadeInImageProps) {
+function FadeInImage({
+  uri,
+  imageStyle,
+  testID,
+  wrapperTestID,
+  onPress,
+}: FadeInImageProps) {
   const opacity = useSharedValue(0);
   const [loaded, setLoaded] = React.useState(false);
   const fadeStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
@@ -41,7 +41,9 @@ function FadeInImage({ uri, imageStyle, testID, wrapperTestID, onPress }: FadeIn
         activeOpacity={0.8}
         accessibilityRole="button"
         accessibilityLabel={
-          isGeneratedImage ? `Generated image ${loaded ? 'loaded' : 'loading'}` : undefined
+          isGeneratedImage
+            ? `Generated image ${loaded ? 'loaded' : 'loading'}`
+            : undefined
         }
       >
         <Image
@@ -52,6 +54,13 @@ function FadeInImage({ uri, imageStyle, testID, wrapperTestID, onPress }: FadeIn
           onLoad={() => {
             setLoaded(true);
             opacity.value = withTiming(1, { duration: 300 });
+          }}
+          onError={event => {
+            logger.error(
+              '[ChatMessage] local image failed to load',
+              event.nativeEvent.error,
+              uri,
+            );
           }}
         />
       </TouchableOpacity>
@@ -79,8 +88,12 @@ function imageAspectRatio(attachment: MediaAttachment): number {
 }
 
 function formatFileSize(bytes: number): string {
-  if (bytes < 1024) { return `${bytes}B`; }
-  if (bytes < 1024 * 1024) { return `${(bytes / 1024).toFixed(0)}KB`; }
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(0)}KB`;
+  }
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
@@ -122,14 +135,16 @@ function ArrivingAttachment({
     >
       <LoadingDots
         size={5}
-        color={isUser ? colors.background : colors.textSecondary}
+        color={colors.primary}
         testID={`attachment-pending-dots-${index}`}
       />
       <Text
         numberOfLines={1}
         style={[
           styles.documentBadgeText,
-          isUser ? styles.documentBadgeTextUser : styles.documentBadgeTextAssistant,
+          isUser
+            ? styles.documentBadgeTextUser
+            : styles.documentBadgeTextAssistant,
         ]}
       >
         {attachment.fileName || 'Arriving'}
@@ -170,9 +185,18 @@ export function MessageAttachments({
             ]}
           >
             <View style={styles.audioBadgeHeader}>
-              <Icon name="mic" size={14} color={isUser ? colors.background : colors.textSecondary} />
+              <Icon
+                name="mic"
+                size={14}
+                color={isUser ? colors.background : colors.textSecondary}
+              />
               <Text
-                style={[styles.documentBadgeText, isUser ? styles.documentBadgeTextUser : styles.documentBadgeTextAssistant]}
+                style={[
+                  styles.documentBadgeText,
+                  isUser
+                    ? styles.documentBadgeTextUser
+                    : styles.documentBadgeTextAssistant,
+                ]}
               >
                 Voice message
               </Text>
@@ -180,7 +204,12 @@ export function MessageAttachments({
             {attachment.textContent ? (
               <Text
                 testID={`audio-transcription-${index}`}
-                style={[styles.audioTranscription, isUser ? styles.documentBadgeTextUser : styles.documentBadgeTextAssistant]}
+                style={[
+                  styles.audioTranscription,
+                  isUser
+                    ? styles.documentBadgeTextUser
+                    : styles.documentBadgeTextAssistant,
+                ]}
               >
                 {attachment.textContent}
               </Text>
@@ -195,8 +224,13 @@ export function MessageAttachments({
               isUser ? styles.documentBadgeUser : styles.documentBadgeAssistant,
             ]}
             onPress={() => {
-              if (!attachment.uri) { return; }
-              const ext = (attachment.fileName || '').split('.').pop()?.toLowerCase();
+              if (!attachment.uri) {
+                return;
+              }
+              const ext = (attachment.fileName || '')
+                .split('.')
+                .pop()
+                ?.toLowerCase();
               const mimeMap: Record<string, string> = {
                 pdf: 'application/pdf',
                 txt: 'text/plain',
@@ -209,7 +243,9 @@ export function MessageAttachments({
                 js: 'text/javascript',
                 ts: 'text/typescript',
               };
-              const mimeType = ext ? mimeMap[ext] || 'application/octet-stream' : undefined;
+              const mimeType = ext
+                ? mimeMap[ext] || 'application/octet-stream'
+                : undefined;
               let uri = attachment.uri;
               if (uri.startsWith('/')) {
                 uri = `file://${uri}`;
@@ -217,17 +253,28 @@ export function MessageAttachments({
                 uri = `file://${uri}`;
               }
               logger.log('[ChatMessage] Opening document:', uri);
-              viewDocument({ uri, mimeType, grantPermissions: 'read' }).catch((err: any) => {
-                logger.warn('[ChatMessage] Failed to open document:', err?.message || err);
-              });
+              viewDocument({ uri, mimeType, grantPermissions: 'read' }).catch(
+                (err: any) => {
+                  logger.warn(
+                    '[ChatMessage] Failed to open document:',
+                    err?.message || err,
+                  );
+                },
+              );
             }}
             activeOpacity={0.7}
           >
-            <Icon name="file-text" size={14} color={isUser ? colors.background : colors.textSecondary} />
+            <Icon
+              name="file-text"
+              size={14}
+              color={isUser ? colors.background : colors.textSecondary}
+            />
             <Text
               style={[
                 styles.documentBadgeText,
-                isUser ? styles.documentBadgeTextUser : styles.documentBadgeTextAssistant,
+                isUser
+                  ? styles.documentBadgeTextUser
+                  : styles.documentBadgeTextAssistant,
               ]}
               numberOfLines={1}
             >
@@ -237,7 +284,9 @@ export function MessageAttachments({
               <Text
                 style={[
                   styles.documentBadgeSize,
-                  isUser ? styles.documentBadgeSizeUser : styles.documentBadgeSizeAssistant,
+                  isUser
+                    ? styles.documentBadgeSizeUser
+                    : styles.documentBadgeSizeAssistant,
                 ]}
               >
                 {formatFileSize(attachment.fileSize)}
@@ -252,11 +301,15 @@ export function MessageAttachments({
               styles.attachmentImage,
               { aspectRatio: imageAspectRatio(attachment) },
             ]}
-            wrapperTestID={isUser ? `message-attachment-${index}` : 'generated-image'}
-            testID={isUser ? `message-image-${index}` : 'generated-image-content'}
+            wrapperTestID={
+              isUser ? `message-attachment-${index}` : 'generated-image'
+            }
+            testID={
+              isUser ? `message-image-${index}` : 'generated-image-content'
+            }
             onPress={() => onImagePress?.(attachment.uri)}
           />
-        )
+        ),
       )}
     </View>
   );

--- a/src/components/ChatMessage/styles.ts
+++ b/src/components/ChatMessage/styles.ts
@@ -11,7 +11,7 @@ import { TYPOGRAPHY, SPACING, FONTS } from '../../constants';
  */
 const MESSAGE_MAX_WIDTH = '85%' as const;
 
-const createBubbleStyles = (colors: ThemeColors) => ({
+const createBubbleStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   container: {
     marginVertical: 8,
     paddingHorizontal: 16,
@@ -118,6 +118,7 @@ const createBubbleStyles = (colors: ThemeColors) => ({
     borderRadius: 8,
     paddingHorizontal: SPACING.lg,
     paddingVertical: SPACING.md,
+    ...shadows.small,
   },
   bubbleWithAttachments: {
     paddingHorizontal: 8,
@@ -448,8 +449,8 @@ const createActionStyles = (colors: ThemeColors) => ({
   },
 });
 
-export const createStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
-  ...createBubbleStyles(colors),
+export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
+  ...createBubbleStyles(colors, shadows),
   ...createThinkingStyles(colors),
   ...createActionStyles(colors),
 });

--- a/src/components/ChatMessage/styles.ts
+++ b/src/components/ChatMessage/styles.ts
@@ -13,7 +13,7 @@ const MESSAGE_MAX_WIDTH = '85%' as const;
 
 const createBubbleStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   container: {
-    marginVertical: 8,
+    marginVertical: 6,
     paddingHorizontal: 16,
   },
   userContainer: {
@@ -47,7 +47,7 @@ const createBubbleStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
    * ONE rhythm for every tool row, whatever produced it.
    *
    * A requested call, a synced artifact and a finished result are the same thing at three moments,
-   * so they get the same container: one row per container, the same 8px above and below, left
+   * so they get the same container: one row per container, the same 6px above and below, left
    * aligned in the assistant column. They used to disagree. A turn's requested calls were grouped
    * N-to-a-container at 2px apart, centred and inset 16px INSIDE the 85% assistant column, while a
    * result stood alone, centred and inset 16px from the SCREEN - two left edges and two gaps, which
@@ -76,8 +76,8 @@ const createBubbleStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   },
   /**
    * The gutter a standalone tool-result message sits in: the same left edge as `container`, and
-   * deliberately NO vertical margin. `container` carries `marginVertical: 8`, which on top of the
-   * row's own 8px padding would space two results 32px apart while the requested calls inside one
+   * deliberately NO vertical margin. `container` carries `marginVertical: 6`, which on top of the
+   * row's own 8px padding would space two results 28px apart while the requested calls inside one
    * assistant turn sat at 16px - the same unequal rhythm, reintroduced from the other side.
    */
   toolMessageRow: {

--- a/src/components/ModelCard.styles.ts
+++ b/src/components/ModelCard.styles.ts
@@ -49,6 +49,13 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   denseMeta: {
     ...TYPOGRAPHY.meta,
     color: colors.textMuted,
+    flex: 1,
+  },
+  denseMetaRow: {
+    flexDirection: 'row' as const,
+    alignItems: 'center' as const,
+    justifyContent: 'space-between' as const,
+    gap: SPACING.sm,
     marginTop: SPACING.xs,
   },
   authorTag: {
@@ -163,16 +170,6 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   recommendedText: {
     color: colors.info,
   },
-  recommendedPill: {
-    backgroundColor: colors.primary,
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 6,
-  },
-  recommendedPillText: {
-    ...TYPOGRAPHY.metaSmall,
-    color: colors.surface,
-  },
   // GPU/NPU capability badge — emerald accent to signal hardware acceleration.
   accelBadge: {
     backgroundColor: `${colors.primary}20`,
@@ -222,12 +219,6 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   },
   progressSection: {
     marginTop: 10,
-    marginBottom: 12,
-  },
-  progressContainer: {
-    flexDirection: 'row' as const,
-    alignItems: 'center' as const,
-    gap: 12,
   },
   progressBar: {
     // Full card width (own row); the caption row below carries bytes + %.
@@ -274,23 +265,39 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     padding: 4,
     flexShrink: 0,
   },
+  downloadActions: {
+    flexDirection: 'row' as const,
+    alignItems: 'center' as const,
+    gap: SPACING.xs,
+  },
+  transferRow: {
+    flexDirection: 'row' as const,
+    alignItems: 'center' as const,
+    gap: SPACING.sm,
+  },
+  transferProgress: {
+    flex: 1,
+  },
   failedSection: {
-    marginTop: 8,
-    paddingTop: 10,
-    borderTopWidth: 1,
-    borderTopColor: colors.border,
+    marginTop: SPACING.xs,
   },
   failedProgressFill: {
     height: '100%' as const,
     backgroundColor: colors.error,
     borderRadius: 4,
   },
+  failedFooterRow: {
+    flexDirection: 'row' as const,
+    alignItems: 'center' as const,
+    justifyContent: 'space-between' as const,
+    gap: SPACING.sm,
+    marginTop: SPACING.xs,
+  },
   failedMessageRow: {
     flexDirection: 'row' as const,
     alignItems: 'center' as const,
     gap: 6,
-    marginTop: 8,
-    marginBottom: 10,
+    flex: 1,
   },
   failedMessageText: {
     ...TYPOGRAPHY.meta,
@@ -299,18 +306,15 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   },
   failedActionsRow: {
     flexDirection: 'row' as const,
-    gap: 8,
+    alignItems: 'center' as const,
+    gap: SPACING.sm,
   },
   retryButton: {
     flexDirection: 'row' as const,
     alignItems: 'center' as const,
     gap: 6,
-    paddingHorizontal: 14,
-    paddingVertical: 7,
-    borderRadius: 8,
-    backgroundColor: `${colors.primary}15` as const,
-    borderWidth: 1,
-    borderColor: `${colors.primary}40` as const,
+    paddingHorizontal: SPACING.xs,
+    paddingVertical: SPACING.xs,
   },
   retryButtonText: {
     ...TYPOGRAPHY.meta,
@@ -320,12 +324,8 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     flexDirection: 'row' as const,
     alignItems: 'center' as const,
     gap: 6,
-    paddingHorizontal: 14,
-    paddingVertical: 7,
-    borderRadius: 8,
-    backgroundColor: `${colors.error}12` as const,
-    borderWidth: 1,
-    borderColor: `${colors.error}30` as const,
+    paddingHorizontal: SPACING.xs,
+    paddingVertical: SPACING.xs,
   },
   removeButtonText: {
     ...TYPOGRAPHY.meta,

--- a/src/components/ModelCard.tsx
+++ b/src/components/ModelCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import Icon from 'react-native-vector-icons/Feather';
 import { useThemedStyles, useTheme } from '../theme';
-import { CREDIBILITY_LABELS } from '../constants';
+import { CREDIBILITY_LABELS, SPACING } from '../constants';
 import { QUANTIZATION_INFO } from '@offgrid/application';
 import { ModelFile, DownloadedModel, ModelCredibility } from '../types';
 import { needsVisionRepair } from '../utils/visionRepair';
@@ -15,8 +15,7 @@ import {
   ModelCardActions,
   RecommendedConfig,
 } from './ModelCardContent';
-import { PAUSED_ICON, QUEUED_ICON } from '../utils/downloadStatusIcon';
-import { formatBytes } from '../utils/formatBytes';
+import { downloadStatusIcon, PAUSED_ICON, QUEUED_ICON } from '../utils/downloadStatusIcon';
 import { presentProgress } from '../utils/progressPresentation';
 
 interface ModelCardProps {
@@ -32,6 +31,8 @@ interface ModelCardProps {
     modelType?: 'text' | 'vision' | 'code';
     paramCount?: number;
     minRamGB?: number;
+    sizeBytes?: number;
+    facts?: string[];
   };
   file?: ModelFile;
   downloadedModel?: DownloadedModel;
@@ -47,6 +48,10 @@ interface ModelCardProps {
   downloadBytes?: { downloaded: number; total: number; bytesPerSecond?: number };
   /** Concurrent downloads behind this card (main+mmproj / grouped) → "N downloads". */
   downloadCount?: number;
+  /** Canonical lifecycle value from Shared. Used only to present non-transfer states. */
+  downloadStatus?: string;
+  /** Human-readable detail for retry, network, preparation, and failure states. */
+  downloadStatusLabel?: string;
   isActive?: boolean;
   isCompatible?: boolean;
   incompatibleReason?: string;
@@ -58,6 +63,8 @@ interface ModelCardProps {
   onRepairVision?: () => void;
   isRepairingVision?: boolean;
   onCancel?: () => void;
+  onPause?: () => void;
+  onResume?: () => void;
   compact?: boolean;
   isTrending?: boolean;
   recommended?: RecommendedConfig;
@@ -67,7 +74,7 @@ interface ModelCardProps {
     errorMessage: string;
     bytesDownloaded: number;
     totalBytes: number;
-    onRetry: () => void;
+    onRetry?: () => void;
     onRemove: () => void;
   };
 }
@@ -77,8 +84,8 @@ function resolveQuantInfo(file?: ModelFile, downloadedModel?: DownloadedModel) {
   return quant ? (QUANTIZATION_INFO[quant] ?? null) : null;
 }
 
-function resolveFileSize(file?: ModelFile, downloadedModel?: DownloadedModel) {
-  const main = file?.size ?? downloadedModel?.fileSize ?? 0;
+function resolveFileSize(file?: ModelFile, downloadedModel?: DownloadedModel, modelSizeBytes?: number) {
+  const main = file?.size ?? downloadedModel?.fileSize ?? modelSizeBytes ?? 0;
   const mmProj = file?.mmProjFile?.size ?? getMmProjFileSize(downloadedModel);
   return main + mmProj;
 }
@@ -103,11 +110,12 @@ interface ModelCardHeadingProps {
   credibilityInfo: { color: string; label: string } | null;
   isActive?: boolean;
   incompatibleReason?: string;
+  denseAction?: React.ReactNode;
 }
 
 const ModelCardHeading: React.FC<ModelCardHeadingProps> = ({
   dense, model, fileSize, quantization, isVisionModel, supportsAcceleration,
-  recommended, isTrending, credibility, credibilityInfo, isActive, incompatibleReason,
+  recommended, isTrending, credibility, credibilityInfo, isActive, incompatibleReason, denseAction,
 }) => dense ? (
   <DenseModelCardContent
     model={model}
@@ -120,6 +128,7 @@ const ModelCardHeading: React.FC<ModelCardHeadingProps> = ({
     credibilitySource={credibility?.source}
     credibilityLabel={credibilityInfo?.label}
     incompatibleReason={incompatibleReason}
+    trailingAction={denseAction}
   />
 ) : (
   <StandardModelCardContent
@@ -154,7 +163,10 @@ const DownloadProgressSection: React.FC<{
   paused?: boolean;
   /** Number of concurrent downloads behind this card (>1 → show "N downloads"). */
   count?: number;
-}> = ({ progress, bytes, queued, paused, count }) => {
+  status?: string;
+  statusLabel?: string;
+  failed?: boolean;
+}> = ({ progress, bytes, queued, paused, count, status, statusLabel, failed }) => {
   const styles = useThemedStyles(createStyles);
   const { colors } = useTheme();
   const presented = presentProgress({
@@ -162,7 +174,7 @@ const DownloadProgressSection: React.FC<{
     bytesDownloaded: bytes?.downloaded,
     totalBytes: bytes?.total,
     bytesPerSecond: bytes?.bytesPerSecond,
-    status: queued ? 'pending' : paused ? 'paused' : 'running',
+    status: status ?? (queued ? 'pending' : paused ? 'paused' : 'running'),
   });
   const percentage = presented.progress.percentage ?? 0;
   // Cumulative download → note how many files are running so the total reads clearly.
@@ -173,7 +185,8 @@ const DownloadProgressSection: React.FC<{
     queued || paused ? undefined : presented.rateText,
     countLabel,
   ].filter(Boolean).join(' · ');
-  const statusLabel = queued ? (
+  const statusIcon = status ? downloadStatusIcon(status) : null;
+  const renderedStatus = queued ? (
     <View style={styles.progressLabelRow}>
       <Icon name={QUEUED_ICON} size={12} color={colors.textMuted} accessibilityLabel="Queued" />
       <Text style={[styles.progressText, styles.queuedText]}>Queued</Text>
@@ -185,6 +198,13 @@ const DownloadProgressSection: React.FC<{
       <Icon name={PAUSED_ICON} size={12} color={colors.textSecondary} accessibilityLabel="Paused" />
       <Text style={[styles.progressText, styles.pausedText]}>Paused</Text>
     </View>
+  ) : statusLabel || statusIcon ? (
+    <View style={styles.progressLabelRow}>
+      {statusIcon && (
+        <Icon name={statusIcon} size={12} color={colors.textMuted} accessibilityLabel={statusLabel} />
+      )}
+      {!!statusLabel && <Text style={styles.progressText}>{statusLabel}</Text>}
+    </View>
   ) : (
     <Text style={styles.progressText}>{presented.percentageText ?? 'In progress'}</Text>
   );
@@ -193,13 +213,13 @@ const DownloadProgressSection: React.FC<{
     {/* Full-width bar so it uses the whole card width. Queued shows an EMPTY bar
         (0 progress) so it reads as "not started yet". */}
     <View style={styles.progressBar}>
-      <View style={[styles.progressFill, { width: `${queued ? 0 : percentage}%` }]} />
+      <View style={[failed ? styles.failedProgressFill : styles.progressFill, { width: `${queued ? 0 : percentage}%` }]} />
     </View>
     {/* Caption row under the bar: bytes (+ "N downloads") on the LEFT, status on the
         RIGHT. "Queued" while waiting for a slot, otherwise the percent. */}
     <View style={styles.progressCaptionRow}>
       <Text style={styles.progressBytesText}>{caption}</Text>
-      {statusLabel}
+      {renderedStatus}
     </View>
   </View>
   );
@@ -209,9 +229,10 @@ const FailedSection: React.FC<{
   errorMessage: string;
   bytesDownloaded: number;
   totalBytes: number;
-  onRetry: () => void;
+  onRetry?: () => void;
   onRemove: () => void;
-}> = ({ errorMessage, bytesDownloaded, totalBytes, onRetry, onRemove }) => {
+  testID?: string;
+}> = ({ errorMessage, bytesDownloaded, totalBytes, onRetry, onRemove, testID }) => {
   const styles = useThemedStyles(createStyles);
   const { colors } = useTheme();
   const presented = presentProgress({
@@ -222,28 +243,29 @@ const FailedSection: React.FC<{
   const progress = presented.progress.percentage ?? 0;
   return (
     <View style={styles.failedSection}>
-      <View style={styles.progressContainer}>
-        <View style={styles.progressBar}>
-          <View style={[styles.failedProgressFill, { width: `${progress}%` }]} />
+      <DownloadProgressSection
+        progress={progress / 100}
+        bytes={{ downloaded: bytesDownloaded, total: totalBytes }}
+        statusLabel={totalBytes > 0 ? undefined : 'Stopped'}
+        failed
+      />
+      <View style={styles.failedFooterRow}>
+        <View style={styles.failedMessageRow}>
+          <Icon name="alert-circle" size={13} color={colors.error} accessibilityLabel="Needs attention" />
+          <Text style={styles.failedMessageText}>{errorMessage}</Text>
         </View>
-        <Text style={styles.progressText}>{presented.percentageText ?? 'Stopped'}</Text>
-      </View>
-      {totalBytes > 0 && (
-        <Text style={styles.progressBytesText}>{formatBytes(bytesDownloaded)} / {formatBytes(totalBytes)}</Text>
-      )}
-      <View style={styles.failedMessageRow}>
-        <Icon name="alert-circle" size={13} color={colors.error} />
-        <Text style={styles.failedMessageText}>{errorMessage}</Text>
-      </View>
-      <View style={styles.failedActionsRow}>
-        <TouchableOpacity style={styles.retryButton} onPress={onRetry}>
-          <Icon name="refresh-cw" size={13} color={colors.primary} />
-          <Text style={styles.retryButtonText}>Retry</Text>
-        </TouchableOpacity>
-        <TouchableOpacity style={styles.removeButton} onPress={onRemove}>
-          <Icon name="trash-2" size={13} color={colors.error} />
-          <Text style={styles.removeButtonText}>Remove</Text>
-        </TouchableOpacity>
+        <View style={styles.failedActionsRow}>
+          {onRetry && (
+            <TouchableOpacity style={styles.retryButton} hitSlop={SPACING.md} onPress={onRetry} testID={testID ? `${testID}-retry` : undefined}>
+              <Icon name="refresh-cw" size={13} color={colors.primary} />
+              <Text style={styles.retryButtonText}>Retry</Text>
+            </TouchableOpacity>
+          )}
+          <TouchableOpacity style={styles.removeButton} hitSlop={SPACING.md} onPress={onRemove} testID={testID ? `${testID}-remove` : undefined}>
+            <Icon name="trash-2" size={13} color={colors.error} />
+            <Text style={styles.removeButtonText}>Remove</Text>
+          </TouchableOpacity>
+        </View>
       </View>
     </View>
   );
@@ -260,6 +282,8 @@ export const ModelCard: React.FC<ModelCardProps> = ({
   downloadProgress = 0,
   downloadBytes,
   downloadCount,
+  downloadStatus,
+  downloadStatusLabel,
   isActive,
   isCompatible = true,
   incompatibleReason,
@@ -271,6 +295,8 @@ export const ModelCard: React.FC<ModelCardProps> = ({
   onRepairVision,
   isRepairingVision,
   onCancel,
+  onPause,
+  onResume,
   compact,
   isTrending,
   recommended,
@@ -281,7 +307,7 @@ export const ModelCard: React.FC<ModelCardProps> = ({
   const useDenseLayout = compact;
 
   const quantInfo = resolveQuantInfo(file, downloadedModel);
-  const fileSize = resolveFileSize(file, downloadedModel);
+  const fileSize = resolveFileSize(file, downloadedModel, model.sizeBytes);
   const isVisionModel = !!(file?.mmProjFile || (downloadedModel?.engine === 'llama' && downloadedModel.isVisionModel));
   const needsRepair = needsVisionRepair(downloadedModel, file);
 
@@ -299,6 +325,27 @@ export const ModelCard: React.FC<ModelCardProps> = ({
   const credibility = resolveCredibility(model, downloadedModel);
   const credibilityInfo = credibility ? CREDIBILITY_LABELS[credibility.source] : null;
   const quantization = file?.quantization ?? downloadedModel?.quantization;
+  const hasTransfer = [isDownloading, isQueued, isPaused].some(Boolean);
+  const actions = !failedState ? (
+    <ModelCardActions
+      isDownloaded={isDownloaded}
+      isDownloading={isDownloading}
+      isQueued={isQueued}
+      isPaused={isPaused}
+      isActive={isActive}
+      isCompatible={isCompatible}
+      incompatibleReason={incompatibleReason}
+      testID={testID}
+      onDownload={onDownload}
+      onSelect={onSelect}
+      onDelete={onDelete}
+      onRepairVision={onRepairVision}
+      isRepairingVision={isRepairingVision}
+      onCancel={onCancel}
+      onPause={onPause}
+      onResume={onResume}
+    />
+  ) : null;
 
   return (
     <TouchableOpacity
@@ -328,6 +375,7 @@ export const ModelCard: React.FC<ModelCardProps> = ({
             credibilityInfo={credibilityInfo}
             isActive={isActive}
             incompatibleReason={!isCompatible ? (incompatibleReason ?? 'Too large') : undefined}
+            denseAction={useDenseLayout && !hasTransfer ? actions : undefined}
           />
 
           {!useDenseLayout && (
@@ -346,8 +394,21 @@ export const ModelCard: React.FC<ModelCardProps> = ({
 
           <ModelDownloadStats compact={compact} downloads={model.downloads} likes={model.likes} styles={styles} />
 
-          {(isDownloading || isQueued || isPaused) && (
-            <DownloadProgressSection progress={downloadProgress} bytes={downloadBytes} queued={isQueued} paused={isPaused} count={downloadCount} />
+          {hasTransfer && (
+            <View style={styles.transferRow}>
+              <View style={styles.transferProgress}>
+                <DownloadProgressSection
+                  progress={downloadProgress}
+                  bytes={downloadBytes}
+                  queued={isQueued}
+                  paused={isPaused}
+                  count={downloadCount}
+                  status={downloadStatus}
+                  statusLabel={downloadStatusLabel}
+                />
+              </View>
+              {actions}
+            </View>
           )}
           {failedState && (
             <FailedSection
@@ -356,28 +417,12 @@ export const ModelCard: React.FC<ModelCardProps> = ({
               totalBytes={failedState.totalBytes}
               onRetry={failedState.onRetry}
               onRemove={failedState.onRemove}
+              testID={testID}
             />
           )}
         </View>
 
-        {!failedState && (
-          <ModelCardActions
-            isDownloaded={isDownloaded}
-            isDownloading={isDownloading}
-            isQueued={isQueued}
-            isPaused={isPaused}
-            isActive={isActive}
-            isCompatible={isCompatible}
-            incompatibleReason={incompatibleReason}
-            testID={testID}
-            onDownload={onDownload}
-            onSelect={onSelect}
-            onDelete={onDelete}
-            onRepairVision={onRepairVision}
-            isRepairingVision={isRepairingVision}
-            onCancel={onCancel}
-          />
-        )}
+        {!useDenseLayout && !hasTransfer && actions}
       </View>
     </TouchableOpacity>
   );

--- a/src/components/ModelCardContent.tsx
+++ b/src/components/ModelCardContent.tsx
@@ -18,7 +18,6 @@ interface CredibilityInfo {
 // ── Compact header (name + author tag + optional downloads + description + type badges) ──
 
 export interface RecommendedConfig {
-  pillLabel?: string;
   /** An extra descriptive line for a curated/recommended model (e.g. "Up to 2x
    *  faster than CPU via GPU"). Rendered as part of the SAME common description
    *  line as every other card — not a separately coloured/positioned highlight. */
@@ -38,6 +37,7 @@ interface DenseModelCardContentProps {
     modelType?: 'text' | 'vision' | 'code';
     paramCount?: number;
     minRamGB?: number;
+    facts?: string[];
   };
   fileSize: number;
   quantization?: string;
@@ -48,6 +48,28 @@ interface DenseModelCardContentProps {
   credibilitySource?: ModelCredibility['source'];
   credibilityLabel?: string;
   incompatibleReason?: string;
+  trailingAction?: React.ReactNode;
+}
+
+function denseModelFacts(input: {
+  model: DenseModelCardContentProps['model'];
+  fileSize: number;
+  quantization?: string;
+  modelType?: string;
+  supportsAcceleration?: boolean;
+  customFacts?: string[];
+  incompatibleReason?: string;
+}): string[] {
+  return input.customFacts ?? input.model.facts ?? [
+    input.fileSize > 0 ? huggingFaceService.formatFileSize(input.fileSize) : undefined,
+    input.quantization,
+    input.modelType,
+    input.model.paramCount ? `${input.model.paramCount}B params` : undefined,
+    input.model.minRamGB ? `${input.model.minRamGB}GB+ RAM` : undefined,
+    input.supportsAcceleration ? 'NPU/GPU' : undefined,
+    input.model.downloads ? `${formatCompactNumber(input.model.downloads)} dl` : undefined,
+    input.incompatibleReason,
+  ].filter((value): value is string => !!value);
 }
 
 /**
@@ -65,6 +87,7 @@ export const DenseModelCardContent: React.FC<DenseModelCardContentProps> = ({
   credibilitySource,
   credibilityLabel,
   incompatibleReason,
+  trailingAction,
 }) => {
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
@@ -77,21 +100,14 @@ export const DenseModelCardContent: React.FC<DenseModelCardContentProps> = ({
       : model.modelType === 'text'
         ? 'Text'
         : undefined;
-  const facts = customFacts ?? [
-    fileSize > 0 ? huggingFaceService.formatFileSize(fileSize) : undefined,
-    quantization,
-    modelType,
-    model.paramCount ? `${model.paramCount}B params` : undefined,
-    model.minRamGB ? `${model.minRamGB}GB+ RAM` : undefined,
-    supportsAcceleration ? 'NPU/GPU' : undefined,
-    model.downloads ? `${formatCompactNumber(model.downloads)} dl` : undefined,
-    incompatibleReason,
-  ].filter((value): value is string => !!value);
+  const facts = denseModelFacts({
+    model, fileSize, quantization, modelType, supportsAcceleration,
+    customFacts, incompatibleReason,
+  });
   const isVerified = credibilitySource === 'verified-quantizer';
   const sourceLabels = [
     model.author,
     isVerified ? undefined : credibilityLabel,
-    recommended ? (recommended.pillLabel ?? 'Recommended') : undefined,
   ].filter((value): value is string => !!value);
 
   return (
@@ -123,8 +139,13 @@ export const DenseModelCardContent: React.FC<DenseModelCardContentProps> = ({
       {!!description && (
         <Text style={styles.denseDescription} numberOfLines={1}>{description}</Text>
       )}
-      {facts.length > 0 && (
-        <Text style={styles.denseMeta} numberOfLines={1}>{facts.join(' · ')}</Text>
+      {(facts.length > 0 || trailingAction) && (
+        <View style={styles.denseMetaRow}>
+          {facts.length > 0 && (
+            <Text style={styles.denseMeta} numberOfLines={1}>{facts.join(' · ')}</Text>
+          )}
+          {trailingAction}
+        </View>
       )}
     </>
   );
@@ -205,12 +226,7 @@ export const StandardModelCardContent: React.FC<StandardModelCardContentProps> =
           </View>
         )}
         {recommended && (
-          <>
-            <MaterialIcon name="whatshot" size={14} color={colors.trending} />
-            <View style={styles.recommendedPill}>
-              <Text style={styles.recommendedPillText}>{recommended.pillLabel ?? 'Recommended'}</Text>
-            </View>
-          </>
+          <MaterialIcon name="whatshot" size={14} color={colors.trending} accessibilityLabel="Recommended" />
         )}
         {/* GPU/NPU capability badge — a LiteRT or Q4_0/Q8_0 quant this device can accelerate. */}
         {supportsAcceleration && (
@@ -332,6 +348,8 @@ interface ModelCardActionsProps {
   onRepairVision: (() => void) | undefined;
   isRepairingVision?: boolean;
   onCancel: (() => void) | undefined;
+  onPause: (() => void) | undefined;
+  onResume: (() => void) | undefined;
 }
 
 const HIT_SLOP = { top: 14, bottom: 14, left: 14, right: 14 };
@@ -364,7 +382,7 @@ function DownloadedActions({ isActive, testID, colors, styles, onSelect, onDelet
     <>
       {isRepairingVision ? (
         <View style={styles.iconButton} testID={tid('repairing-vision')}>
-          <LoadingDots color={colors.warning} />
+          <LoadingDots color={colors.primary} />
         </View>
       ) : (
         onRepairVision && <ActionButton icon="tool" color={colors.warning} haptic="impactLight" onPress={onRepairVision} testID={tid('repair-vision')} styles={styles} />
@@ -378,13 +396,24 @@ function DownloadedActions({ isActive, testID, colors, styles, onSelect, onDelet
 export const ModelCardActions: React.FC<ModelCardActionsProps> = ({
   isDownloaded, isDownloading, isQueued, isPaused, isActive, isCompatible,
   testID, onDownload, onSelect, onDelete, onRepairVision, isRepairingVision, onCancel,
+  onPause, onResume,
 }) => {
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
   const tid = (suffix: string) => testID ? `${testID}-${suffix}` : undefined;
 
   if ((isDownloading || isQueued || isPaused) && onCancel) {
-    return <ActionButton icon="x" color={colors.error} haptic="notificationWarning" onPress={onCancel} testID={tid('cancel')} styles={styles} />;
+    return (
+      <View style={styles.downloadActions}>
+        {isDownloading && onPause && (
+          <ActionButton icon="pause" color={colors.textSecondary} haptic="impactLight" onPress={onPause} testID={tid('pause')} accessibilityLabel="Pause download" styles={styles} />
+        )}
+        {isPaused && onResume && (
+          <ActionButton icon="play" color={colors.textSecondary} haptic="impactLight" onPress={onResume} testID={tid('resume')} accessibilityLabel="Resume download" styles={styles} />
+        )}
+        <ActionButton icon="x" color={colors.error} haptic="notificationWarning" onPress={onCancel} testID={tid('cancel')} accessibilityLabel="Cancel download" styles={styles} />
+      </View>
+    );
   }
   if (!isDownloaded && onDownload) {
     return <ActionButton icon="download" color={colors.primary} haptic="impactLight" onPress={onDownload} disabled={!isCompatible} testID={tid('download')} styles={styles} />;

--- a/src/components/ScreenHeader.tsx
+++ b/src/components/ScreenHeader.tsx
@@ -4,7 +4,7 @@ import Icon from 'react-native-vector-icons/Feather';
 import { SPACING, TYPOGRAPHY } from '../constants';
 
 /** A small Button (10px padding + one text line) plus the header's own padding. */
-const TAB_HEADER_MIN_HEIGHT = 56;
+const TAB_HEADER_MIN_HEIGHT = 52;
 import { useTheme, useThemedStyles } from '../theme';
 import type { ThemeColors, ThemeShadows } from '../theme';
 
@@ -82,7 +82,7 @@ const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   // as two different sizes across tabs.
   tabHeader: {
     paddingHorizontal: SPACING.md,
-    paddingVertical: SPACING.sm,
+    paddingVertical: SPACING.xs,
     minHeight: TAB_HEADER_MIN_HEIGHT,
   },
   backButton: { padding: SPACING.xs },

--- a/src/components/SettingsOptionSelect.tsx
+++ b/src/components/SettingsOptionSelect.tsx
@@ -71,7 +71,7 @@ export const SettingsOptionSelect: React.FC<SettingsOptionSelectProps> = ({
   );
 };
 
-const createStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
+const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   container: { gap: SPACING.xs as number, marginBottom: SPACING.md },
   label: { ...TYPOGRAPHY.label, color: colors.textMuted, textTransform: 'uppercase' as const },
   trigger: {
@@ -79,6 +79,7 @@ const createStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
     paddingHorizontal: SPACING.md, flexDirection: 'row' as const,
     alignItems: 'center' as const, justifyContent: 'space-between' as const,
     backgroundColor: colors.surface,
+    ...shadows.small,
   },
   value: { ...TYPOGRAPHY.body, color: colors.text, flex: 1 },
   description: { ...TYPOGRAPHY.meta, color: colors.textMuted },

--- a/src/components/VoiceRecordButton/styles.ts
+++ b/src/components/VoiceRecordButton/styles.ts
@@ -24,6 +24,7 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     backgroundColor: colors.surfaceLight,
     alignItems: 'center' as const,
     justifyContent: 'center' as const,
+    ...shadows.small,
   },
   buttonAsSend: {
     width: 44,
@@ -32,7 +33,6 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     backgroundColor: colors.surface,
     borderWidth: 1,
     borderColor: colors.border,
-    ...shadows.small,
   },
   // Audio (voice) mode: a larger, clearly-circular bordered mic so it reads as
   // the primary "press to speak" action.
@@ -52,7 +52,6 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     borderWidth: 1,
     borderColor: colors.border,
     opacity: 0.5,
-    ...shadows.small,
   },
   buttonAsSendLoading: {
     width: 44,
@@ -61,7 +60,6 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     backgroundColor: colors.surface,
     borderWidth: 1,
     borderColor: colors.primary,
-    ...shadows.small,
   },
   // Background STT download (send-slot footprint): a STATIC determinate ring —
   // per-quadrant border colors are set from ringQuadrants at render. Matches the
@@ -72,7 +70,6 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     borderRadius: 22,
     backgroundColor: colors.surface,
     borderWidth: 2,
-    ...shadows.small,
   },
   // Background STT download at the default 36px mic footprint (non-send variants).
   buttonDownloadRing: {

--- a/src/components/VoiceRecordButton/styles.ts
+++ b/src/components/VoiceRecordButton/styles.ts
@@ -24,7 +24,6 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     backgroundColor: colors.surfaceLight,
     alignItems: 'center' as const,
     justifyContent: 'center' as const,
-    ...shadows.small,
   },
   buttonAsSend: {
     width: 44,
@@ -33,6 +32,7 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     backgroundColor: colors.surface,
     borderWidth: 1,
     borderColor: colors.border,
+    ...shadows.small,
   },
   // Audio (voice) mode: a larger, clearly-circular bordered mic so it reads as
   // the primary "press to speak" action.
@@ -52,6 +52,7 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     borderWidth: 1,
     borderColor: colors.border,
     opacity: 0.5,
+    ...shadows.small,
   },
   buttonAsSendLoading: {
     width: 44,
@@ -60,6 +61,7 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     backgroundColor: colors.surface,
     borderWidth: 1,
     borderColor: colors.primary,
+    ...shadows.small,
   },
   // Background STT download (send-slot footprint): a STATIC determinate ring —
   // per-quadrant border colors are set from ringQuadrants at render. Matches the
@@ -70,6 +72,7 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
     borderRadius: 22,
     backgroundColor: colors.surface,
     borderWidth: 2,
+    ...shadows.small,
   },
   // Background STT download at the default 36px mic footprint (non-send variants).
   buttonDownloadRing: {

--- a/src/components/VoiceRecordButton/styles.ts
+++ b/src/components/VoiceRecordButton/styles.ts
@@ -1,6 +1,6 @@
 import type { ThemeColors, ThemeShadows } from '../../theme';
 
-export const createStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
+export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   container: {
     alignItems: 'center' as const,
     justifyContent: 'center' as const,
@@ -24,6 +24,7 @@ export const createStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
     backgroundColor: colors.surfaceLight,
     alignItems: 'center' as const,
     justifyContent: 'center' as const,
+    ...shadows.small,
   },
   buttonAsSend: {
     width: 44,

--- a/src/components/modelDeleteConfirmation.ts
+++ b/src/components/modelDeleteConfirmation.ts
@@ -1,0 +1,18 @@
+import { showAlert, type AlertState } from './CustomAlert';
+import { formatBytes } from '../utils/formatBytes';
+
+/** One confirmation contract for destructive model removal on every model surface. */
+export function buildModelDeleteConfirmation(input: {
+  readonly fileName: string;
+  readonly totalBytes: number;
+  readonly onDelete: () => void;
+}): AlertState {
+  return showAlert(
+    'Delete Model',
+    `Are you sure you want to delete "${input.fileName}"? This will free up ${formatBytes(input.totalBytes)}.`,
+    [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Delete', style: 'destructive', onPress: input.onDelete },
+    ],
+  );
+}

--- a/src/screens/ChatListToolbar.tsx
+++ b/src/screens/ChatListToolbar.tsx
@@ -117,7 +117,7 @@ export const ChatSearchEmpty: React.FC = () => {
   );
 };
 
-const createStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
+const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   toolbar: {
     flexDirection: 'row' as const,
     alignItems: 'center' as const,
@@ -136,6 +136,7 @@ const createStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
     borderColor: colors.border,
     borderRadius: 8,
     backgroundColor: colors.surface,
+    ...shadows.small,
   },
   searchInput: {
     ...TYPOGRAPHY.bodySmall,
@@ -151,6 +152,9 @@ const createStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
     height: 40,
     alignItems: 'center' as const,
     justifyContent: 'center' as const,
+    borderRadius: 8,
+    backgroundColor: colors.surface,
+    ...shadows.small,
   },
   checkbox: {
     width: 20,

--- a/src/screens/ChatScreen/ChatMessageArea.tsx
+++ b/src/screens/ChatScreen/ChatMessageArea.tsx
@@ -47,11 +47,10 @@ export type ChatMessageAreaProps = {
 // The container already pads its bottom by 8, so cap the extra footer at 4 → 12
 // total, symmetric with the top. Collapses to 0 while the keyboard is up.
 //
-// BUT that cap only applies to a thin overlay inset (iOS home indicator / gesture
-// nav), which draws *over* content. A 3-button navigation bar is opaque and owns
-// real space at the bottom — capping there renders the input controls UNDER the
-// nav buttons. We distinguish by the inset size (not Platform.OS): anything above
-// the overlay threshold is a real nav bar, so honor the full inset and clear it.
+// iOS reports its home-indicator overlay at about 34px on many devices. Android can
+// report a similarly tall inset for an opaque 3-button navigation bar. The size
+// alone cannot distinguish them: iOS is always an overlay here, while only Android
+// needs the tall-inset exception for real navigation controls.
 const FOOTER_SAFE_CAP = 4;
 // Home-indicator / gesture-nav overlays sit at ~24px or below on the devices we
 // target; a 3-button nav bar is taller. Above this, treat the inset as opaque.
@@ -59,8 +58,10 @@ const OVERLAY_INSET_MAX = 24;
 export const computeFooterPaddingBottom = (
   keyboardVisible: boolean,
   insetBottom: number,
+  platform: typeof Platform.OS = Platform.OS,
 ): number => {
   if (keyboardVisible) return 0;
+  if (platform === 'ios') return Math.min(insetBottom, FOOTER_SAFE_CAP);
   // Opaque nav bar (tall inset): pad the full inset so controls clear it.
   if (insetBottom > OVERLAY_INSET_MAX) return insetBottom;
   // Thin overlay inset: keep the symmetric-with-top cap.
@@ -214,6 +215,7 @@ export const ChatMessageArea: React.FC<ChatMessageAreaProps> = ({
   const footerPaddingBottom = computeFooterPaddingBottom(
     keyboardVisible,
     insets.bottom,
+    Platform.OS,
   );
   const isStreaming = chat.isStreaming || chat.isThinking;
   const prevIsStreamingRef = useRef(isStreaming);

--- a/src/screens/ChatScreen/styles.ts
+++ b/src/screens/ChatScreen/styles.ts
@@ -12,7 +12,7 @@ const createLayoutStyles = (colors: ThemeColors) => ({
   messageList: { paddingVertical: 16 },
 });
 
-const createHeaderStyles = (colors: ThemeColors) => ({
+const createHeaderStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   header: {
     paddingHorizontal: 16,
     paddingTop: 16,
@@ -20,6 +20,7 @@ const createHeaderStyles = (colors: ThemeColors) => ({
     borderBottomWidth: 1,
     borderBottomColor: colors.border,
     backgroundColor: colors.background,
+    ...shadows.bottom,
     zIndex: 10,
   },
   headerRow: {
@@ -235,7 +236,7 @@ const createIndicatorStyles = (colors: ThemeColors) => ({
 
 export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   ...createLayoutStyles(colors),
-  ...createHeaderStyles(colors),
+  ...createHeaderStyles(colors, shadows),
   ...createScrollStyles(colors),
   ...createEmptyChatStyles(colors),
   ...createStateScreenStyles(colors),

--- a/src/screens/DownloadManagerScreen/downloadItemMapping.ts
+++ b/src/screens/DownloadManagerScreen/downloadItemMapping.ts
@@ -5,9 +5,11 @@ import { DownloadedModel, ONNXImageModel } from '../../types';
 import { DownloadItem } from './items';
 import { imageBackendLabel } from '../../utils/imageBackend';
 import { downloadFileRoleLabel } from '../../utils/downloadStatus';
-import type { ModelsSnapshot } from '@offgrid/application';
+import {
+  describeModelCredibility,
+  type ModelsSnapshot,
+} from '@offgrid/application';
 import { mobileImageDownloadMetadata } from '../../services/modelServices/modelDownloadRequests';
-import { describeModelCredibility } from '@offgrid/models';
 
 /**
  * How a download store row, a queued start, or a finished model becomes one Download Manager row.

--- a/src/screens/DownloadManagerScreen/downloadItemMapping.ts
+++ b/src/screens/DownloadManagerScreen/downloadItemMapping.ts
@@ -7,6 +7,7 @@ import { imageBackendLabel } from '../../utils/imageBackend';
 import { downloadFileRoleLabel } from '../../utils/downloadStatus';
 import type { ModelsSnapshot } from '@offgrid/application';
 import { mobileImageDownloadMetadata } from '../../services/modelServices/modelDownloadRequests';
+import { describeModelCredibility } from '@offgrid/models';
 
 /**
  * How a download store row, a queued start, or a finished model becomes one Download Manager row.
@@ -32,6 +33,9 @@ export function facadeDownloadToActiveItem(
     ? mobileImageDownloadMetadata(entry.metadataJson)
     : undefined;
   const total = entry.totalBytes;
+  const author = image
+    ? getImageAuthor(image.imageModelBackend)
+    : entry.modelId.split('/')[0] ?? 'Unknown';
   return {
     type: 'active',
     modelType,
@@ -41,16 +45,36 @@ export function facadeDownloadToActiveItem(
     // A multi-file model names the part it is fetching by its published ROLE, so a projector
     // reads as "Vision support" rather than an opaque filename. Image models keep their own name.
     fileName: image?.imageModelName ?? downloadFileRoleLabel(entry.currentFileRole, entry.fileName),
-    author: image
-      ? getImageAuthor(image.imageModelBackend)
-      : entry.modelId.split('/')[0] ?? 'Unknown',
+    author,
+    credibility: modelType === 'text' ? describeModelCredibility(author) : undefined,
+    metadataJson: entry.metadataJson,
     quantization: image?.imageModelBackend === 'coreml' ? 'Core ML' : '',
     fileSize: total,
     bytesDownloaded: entry.bytesDownloaded,
+    bytesPerSecond: entry.bytesPerSecond,
     progress: total > 0 ? entry.bytesDownloaded / total : 0,
     status: entry.status,
     reason: entry.reason,
     reasonCode: entry.reasonCode as DownloadItem['reasonCode'],
+  };
+}
+
+/** Present a Shared-owned projector repair with the same transfer facts as every download card. */
+export function projectorRepairToActiveItem(
+  operation: ModelsSnapshot['operations']['active'][number],
+  installed: DownloadItem,
+): DownloadItem {
+  const progress = operation.progress;
+  return {
+    ...installed,
+    type: 'active',
+    downloadId: operation.operationId,
+    fileName: 'Vision support',
+    fileSize: progress?.totalBytes ?? 0,
+    bytesDownloaded: progress?.bytesDownloaded ?? 0,
+    bytesPerSecond: progress?.bytesPerSecond,
+    progress: progress ? progress.percent / 100 : 0,
+    status: 'downloading',
   };
 }
 

--- a/src/screens/DownloadManagerScreen/index.tsx
+++ b/src/screens/DownloadManagerScreen/index.tsx
@@ -48,6 +48,7 @@ export const DownloadManagerScreen: React.FC = () => {
     handleResumeDownload,
     handleDeleteItem,
     handleRepairVision,
+    handleCancelVisionRepair,
     isRepairingVision,
     repairDownloadFor,
     totalStorageUsed,
@@ -129,7 +130,7 @@ export const DownloadManagerScreen: React.FC = () => {
                   )}
                 </View>
                 {filteredActive.map(item => (
-                  <View key={`active-${item.modelId}-${item.fileName}`}>
+                  <View key={`active-${item.modelId}-${item.fileName}`} style={styles.activeCardContainer}>
                     <ActiveDownloadCard
                       item={item}
                       onRemove={handleRemoveDownload}
@@ -158,6 +159,7 @@ export const DownloadManagerScreen: React.FC = () => {
                       item={item}
                       onDelete={handleDeleteItem}
                       onRepairVision={handleRepairVision}
+                      onCancelRepair={handleCancelVisionRepair}
                       isRepairingVision={isRepairingVision(item.modelId)}
                       repairDownload={repairDownloadFor(item.modelId)}
                     />

--- a/src/screens/DownloadManagerScreen/items.tsx
+++ b/src/screens/DownloadManagerScreen/items.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { LoadingDots } from '../../components/LoadingDots';
+import { ModelCard } from '../../components/ModelCard';
 import Icon from 'react-native-vector-icons/Feather';
 import { Card } from '../../components/Card';
 import { useTheme, useThemedStyles } from '../../theme';
 import { BackgroundDownloadReasonCode } from '../../types';
+import type { ModelCredibility } from '../../types';
 import { needsVisionRepair as checkNeedsVisionRepair } from '../../utils/visionRepair';
 import { getDownloadStatusLabel, isRetryable } from '../../utils/downloadErrors';
-import { downloadStatusIcon } from '../../utils/downloadStatusIcon';
 import { formatBytes } from '../../utils/formatBytes';
 import { createStyles } from './styles';
 import { presentProgress } from '../../utils/progressPresentation';
-import { SPACING } from '../../constants';
 import { isDownloadingStatus, isPausedStatus } from '../../utils/downloadStatus';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -38,6 +38,8 @@ export type DownloadItem = {
   reason?: string;
   reasonCode?: BackgroundDownloadReasonCode;
   name?: string;
+  credibility?: ModelCredibility;
+  metadataJson?: string;
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -62,7 +64,7 @@ export function getStatusText(status: string): string {
 }
 
 function getStatusLabel(item: DownloadItem): string {
-  if (item.status === 'running') return '';
+  if (isDownloadingStatus(item.status)) return '';
   if (item.status === 'failed' || item.status === 'retrying' || item.status === 'pending' || item.status === 'waiting_for_network') {
     return getDownloadStatusLabel(item.status, item.reasonCode, item.reason);
   }
@@ -80,142 +82,31 @@ interface ActiveDownloadCardProps {
   onResume: (item: DownloadItem) => void;
 }
 
-const DownloadControlActions: React.FC<ActiveDownloadCardProps> = ({
-  item,
-  onRemove,
-  onPause,
-  onResume,
-}) => {
-  const { colors } = useTheme();
-  const styles = useThemedStyles(createStyles);
-  const paused = isPausedStatus(item.status);
-  const canPauseOrResume = isDownloadingStatus(item.status) || paused;
-  return (
-    <View style={styles.downloadActionsRow}>
-      {canPauseOrResume && (
-        <TouchableOpacity
-          style={styles.downloadActionButton}
-          hitSlop={SPACING.md}
-          accessibilityLabel={paused ? 'Resume download' : 'Pause download'}
-          testID={paused ? 'resume-download-button' : 'pause-download-button'}
-          onPress={() => paused ? onResume(item) : onPause(item)}
-        >
-          <Icon name={paused ? 'play' : 'pause'} size={18} color={colors.textSecondary} />
-        </TouchableOpacity>
-      )}
-      <TouchableOpacity
-        style={styles.downloadActionButton}
-        hitSlop={SPACING.md}
-        accessibilityLabel="Cancel download"
-        testID="remove-download-button"
-        onPress={() => onRemove(item)}
-      >
-        <Icon name="x" size={20} color={colors.error} />
-      </TouchableOpacity>
-    </View>
-  );
-};
-
 export const ActiveDownloadCard: React.FC<ActiveDownloadCardProps> = ({ item, onRemove, onRetry, onPause, onResume }) => {
-  const { colors } = useTheme();
-  const styles = useThemedStyles(createStyles);
   const needsAttention = item.status === 'failed' || item.status === 'interrupted';
-  const progressColor =
-    needsAttention
-      ? colors.error
-      : item.status === 'retrying' || item.status === 'waiting_for_network'
-        ? colors.warning
-        : colors.primary;
-  const presented = presentProgress({
-    progress: item.progress,
-    bytesDownloaded: item.bytesDownloaded,
-    totalBytes: item.fileSize,
-    bytesPerSecond: item.bytesPerSecond,
-    status: item.status,
-  });
-  const percentage = presented.progress.percentage ?? 0;
-
-  // Icon per status is owned by downloadStatusIcon() so this row and ModelCard match
-  // (queued -> clock, previously text-only here).
-  const getStatusIcon = () => downloadStatusIcon(item.status);
-
-  const getStatusIconColor = () => {
-    if (needsAttention) return colors.error;
-    if (item.status === 'retrying') return colors.warning;
-    if (item.status === 'waiting_for_network') return colors.warning;
-    return colors.textMuted;
-  };
-
   return (
-    <Card style={styles.downloadCard}>
-      <View style={styles.downloadHeader}>
-        <View style={styles.downloadInfo}>
-          <Text style={styles.fileName} numberOfLines={1}>{item.fileName}</Text>
-          <Text style={styles.modelId} numberOfLines={1}>{item.author}</Text>
-        </View>
-        {needsAttention ? (
-          <View style={styles.failedActionsRow}>
-            {isRetryable(item.reasonCode) && (
-              <TouchableOpacity
-                style={styles.retryButton}
-                hitSlop={SPACING.md}
-                testID="failed-retry-button"
-                onPress={() => onRetry(item)}
-              >
-                <Icon name="refresh-cw" size={14} color={colors.primary} />
-                <Text style={styles.retryButtonText}>Retry</Text>
-              </TouchableOpacity>
-            )}
-            <TouchableOpacity
-              style={styles.removeButton}
-              hitSlop={SPACING.md}
-              testID="failed-remove-button"
-              onPress={() => onRemove(item)}
-            >
-              <Icon name="trash-2" size={14} color={colors.error} />
-              <Text style={styles.removeButtonText}>Remove</Text>
-            </TouchableOpacity>
-          </View>
-        ) : (
-          <DownloadControlActions
-            item={item}
-            onRemove={onRemove}
-            onRetry={onRetry}
-            onPause={onPause}
-            onResume={onResume}
-          />
-        )}
-      </View>
-      <View style={styles.progressContainer}>
-        <View style={styles.progressBarBackground}>
-          <View style={[styles.progressBarFill, { width: `${percentage}%` as const, backgroundColor: progressColor }]} />
-        </View>
-        <Text style={styles.progressText} testID="download-progress-detail">
-          {[presented.percentageText, presented.detailText].filter(Boolean).join(' · ')}
-        </Text>
-      </View>
-      <View style={styles.downloadMeta}>
-        {!!item.quantization && (
-          <View style={styles.quantBadge}>
-            <Text style={styles.quantText}>{item.quantization}</Text>
-          </View>
-        )}
-        {(!!getStatusLabel(item) || !!getStatusIcon()) && (
-          <View style={styles.statusIconRow}>
-            {getStatusIcon() && (
-              <Icon name={getStatusIcon()!} size={14} color={getStatusIconColor()} accessibilityLabel={getStatusText(item.status)} />
-            )}
-            {/* Queued is icon-only (clock) — the word is redundant next to it. Other states
-                (failed/retrying/network) keep their explanatory text. */}
-            {item.status !== 'pending' && item.status !== 'queued' && !!getStatusLabel(item) && (
-              <Text style={[styles.statusText, needsAttention && { color: colors.error }]}>
-                {getStatusLabel(item)}
-              </Text>
-            )}
-          </View>
-        )}
-      </View>
-    </Card>
+    <ModelCard
+      compact
+      testID="active-download-card"
+      model={{ id: item.modelId, name: item.fileName, author: item.author, credibility: item.credibility }}
+      isDownloading={!needsAttention && !isPausedStatus(item.status) && item.status !== 'queued' && item.status !== 'pending'}
+      isQueued={item.status === 'queued' || item.status === 'pending'}
+      isPaused={isPausedStatus(item.status)}
+      downloadProgress={item.progress}
+      downloadBytes={{ downloaded: item.bytesDownloaded, total: item.fileSize, bytesPerSecond: item.bytesPerSecond }}
+      downloadStatus={item.status}
+      downloadStatusLabel={getStatusLabel(item)}
+      onPause={isDownloadingStatus(item.status) ? () => onPause(item) : undefined}
+      onResume={isPausedStatus(item.status) ? () => onResume(item) : undefined}
+      onCancel={!needsAttention ? () => onRemove(item) : undefined}
+      failedState={needsAttention ? {
+        errorMessage: getStatusLabel(item),
+        bytesDownloaded: item.bytesDownloaded,
+        totalBytes: item.fileSize,
+        onRetry: isRetryable(item.reasonCode) ? () => onRetry(item) : undefined,
+        onRemove: () => onRemove(item),
+      } : undefined}
+    />
   );
 };
 
@@ -223,6 +114,7 @@ interface CompletedDownloadCardProps {
   item: DownloadItem;
   onDelete: (item: DownloadItem) => void;
   onRepairVision?: (item: DownloadItem) => void;
+  onCancelRepair?: (item: DownloadItem) => void;
   isRepairingVision?: boolean;
   repairDownload?: DownloadItem;
 }
@@ -245,7 +137,7 @@ function modelTypeIconColor(item: DownloadItem, needsVisionRepair: boolean, colo
   return colors.primary;
 }
 
-export const CompletedDownloadCard: React.FC<CompletedDownloadCardProps> = ({ item, onDelete, onRepairVision, isRepairingVision = false, repairDownload }) => {
+export const CompletedDownloadCard: React.FC<CompletedDownloadCardProps> = ({ item, onDelete, onRepairVision, onCancelRepair, isRepairingVision = false, repairDownload }) => {
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
   const needsVisionRepair = checkNeedsVisionRepair(item);
@@ -290,13 +182,24 @@ export const CompletedDownloadCard: React.FC<CompletedDownloadCardProps> = ({ it
             <Icon name="tool" size={18} color={colors.warning} />
           </TouchableOpacity>
         )}
-        <TouchableOpacity
-          style={styles.deleteButton}
-          testID="delete-model-button"
-          onPress={() => onDelete(item)}
-        >
-          <Icon name="trash-2" size={18} color={colors.error} />
-        </TouchableOpacity>
+        {isRepairingVision && onCancelRepair ? (
+          <TouchableOpacity
+            style={styles.deleteButton}
+            testID="cancel-vision-repair-button"
+            accessibilityLabel="Cancel vision repair"
+            onPress={() => onCancelRepair(item)}
+          >
+            <Icon name="x" size={18} color={colors.error} />
+          </TouchableOpacity>
+        ) : (
+          <TouchableOpacity
+            style={styles.deleteButton}
+            testID="delete-model-button"
+            onPress={() => onDelete(item)}
+          >
+            <Icon name="trash-2" size={18} color={colors.error} />
+          </TouchableOpacity>
+        )}
       </View>
       {isRepairingVision && (
         <View style={styles.repairingBadge} testID="repairing-vision-badge">

--- a/src/screens/DownloadManagerScreen/styles.ts
+++ b/src/screens/DownloadManagerScreen/styles.ts
@@ -36,6 +36,9 @@ export const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   section: {
     marginBottom: SPACING.sm,
   },
+  activeCardContainer: {
+    marginHorizontal: SPACING.md,
+  },
   sectionHeader: {
     flexDirection: 'row' as const,
     alignItems: 'center' as const,

--- a/src/screens/DownloadManagerScreen/useDownloadManager.ts
+++ b/src/screens/DownloadManagerScreen/useDownloadManager.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import {
   AlertState,
   showAlert,
@@ -20,10 +20,18 @@ import { DownloadItem, formatBytes } from './items';
 import {
   facadeDownloadToActiveItem,
   modelStoreCompletedItems,
+  projectorRepairToActiveItem,
 } from './downloadItemMapping';
 import logger from '../../utils/logger';
 import { useModelDownloadsProjection } from '../../hooks/useModelDownloadsProjection';
 import { applicationFacade } from '../../services/applicationFacade';
+import { useModelsProjection } from '../../hooks/useApplicationProjection';
+import { buildModelDeleteConfirmation } from '../../components/modelDeleteConfirmation';
+import { autoSetupImageCatalogProvider } from '../../services/autoSetupImageCatalogProvider';
+import { mobileImageDownloadSelection } from '../../services/adapters/models/modelControlCatalogPort';
+import { mobileImageDownloadMetadata } from '../../services/modelServices/modelDownloadRequests';
+import { imageDownloadDescriptorFromMetadata } from '@offgrid/models';
+import { isFailedStatus } from '../../utils/downloadStatus';
 
 export interface UseDownloadManagerResult {
   activeItems: DownloadItem[];
@@ -36,6 +44,7 @@ export interface UseDownloadManagerResult {
   handleResumeDownload: (item: DownloadItem) => void;
   handleDeleteItem: (item: DownloadItem) => void;
   handleRepairVision: (item: DownloadItem) => void;
+  handleCancelVisionRepair: (item: DownloadItem) => void;
   isRepairingVision: (modelId: string) => boolean;
   repairDownloadFor: (modelId: string) => DownloadItem | undefined;
   totalStorageUsed: number;
@@ -43,15 +52,6 @@ export interface UseDownloadManagerResult {
 
 export function useDownloadManager(): UseDownloadManagerResult {
   const [alertState, setAlertState] = useState<AlertState>(initialAlertState);
-  const [repairingVisionIds, setRepairingVisionIds] = useState<Record<string, boolean>>({});
-  const setRepairingVision = useCallback((id: string, repairing: boolean) => {
-    setRepairingVisionIds(current => {
-      if (repairing) return { ...current, [id]: true };
-      const next = { ...current };
-      delete next[id];
-      return next;
-    });
-  }, []);
   // Narrow selectors. A zero-argument `useAppStore()` re-rendered this whole screen for every
   // unrelated store write - image-generation progress, chat state, a settings change - while a
   // download was already re-rendering it on its own progress.
@@ -59,6 +59,9 @@ export function useDownloadManager(): UseDownloadManagerResult {
   const downloadedImageModels = useAppStore(state => state.downloadedImageModels);
 
   const downloads = useModelDownloadsProjection();
+  const projectorRepairs = useModelsProjection().operations.active.filter(
+    operation => operation.kind === 'projector_repair' && operation.state === 'active',
+  );
 
   // Voice (TTS) + transcription (STT) downloaded models, loaded from disk.
   const { voiceItems, buildDeleteAlert: buildVoiceDeleteAlert } =
@@ -84,10 +87,11 @@ export function useDownloadManager(): UseDownloadManagerResult {
     .filter(item => !completedIds.has(idOf(item)));
   const activeItems: DownloadItem[] = startedItems;
   const repairDownloadFor = (modelId: string): DownloadItem | undefined => {
-    const row = downloads.find(
-      download => download.modelKey === modelId || download.modelId === modelId,
-    );
-    return row ? facadeDownloadToActiveItem(row) : undefined;
+    const operation = projectorRepairs.find(repair => repair.modelId === modelId);
+    const installed = completedItems.find(item => item.modelId === modelId);
+    return operation && installed
+      ? projectorRepairToActiveItem(operation, installed)
+      : undefined;
   };
 
   const totalStorageUsed = completedItems.reduce(
@@ -99,7 +103,7 @@ export function useDownloadManager(): UseDownloadManagerResult {
     setAlertState(hideAlert());
     try {
       const outcome = await applicationFacade().models.control({
-        type: 'cancel-download',
+        type: 'clear-download',
         modelId: item.downloadId ?? item.modelId,
       });
       if (!outcome.ok) throw new Error(modelsFailureMessage(outcome.failure));
@@ -109,11 +113,37 @@ export function useDownloadManager(): UseDownloadManagerResult {
     }
   };
 
+  const executeCancelDownload = async (item: DownloadItem) => {
+    try {
+      const outcome = await applicationFacade().models.control({
+        type: 'cancel-download',
+        modelId: item.downloadId ?? item.modelId,
+      });
+      if (!outcome.ok) throw new Error(modelsFailureMessage(outcome.failure));
+    } catch (error) {
+      logger.error('[DownloadManager] Failed to cancel download:', error);
+      setAlertState(showAlert('Cancel Failed', 'Failed to cancel download'));
+    }
+  };
+
   const handleRetryDownload = async (item: DownloadItem) => {
     try {
+      let selection;
+      if (item.modelType === 'image') {
+        const descriptorId = item.modelId.replace(/^image:/, '');
+        const persisted = mobileImageDownloadMetadata(item.metadataJson);
+        const descriptor = persisted
+          ? imageDownloadDescriptorFromMetadata(descriptorId, persisted)
+          : (await autoSetupImageCatalogProvider.load()).find(
+              candidate => candidate.id === descriptorId,
+            );
+        selection = descriptor ? mobileImageDownloadSelection(descriptor) : null;
+        if (!selection) throw new Error('The image model source is no longer available.');
+      }
       const outcome = await applicationFacade().models.control({
         type: 'retry-download',
         modelId: item.downloadId ?? item.modelId,
+        ...(selection ? { selection } : {}),
       });
       if (!outcome.ok) throw new Error(modelsFailureMessage(outcome.failure));
     } catch (error: any) {
@@ -152,6 +182,10 @@ export function useDownloadManager(): UseDownloadManagerResult {
   };
 
   const handleRemoveDownload = (item: DownloadItem) => {
+    if (!isFailedStatus(item.status) && item.status !== 'interrupted') {
+      executeCancelDownload(item);
+      return;
+    }
     setAlertState(
       showAlert(
         'Remove Download',
@@ -222,24 +256,11 @@ export function useDownloadManager(): UseDownloadManagerResult {
       const model = downloadedModels.find(m => m.id === item.modelId);
       if (!model) return;
       const totalSize = hardwareService.getModelTotalSize(model);
-      setAlertState(
-        showAlert(
-          'Delete Model',
-          `Are you sure you want to delete "${
-            model.fileName
-          }"? This will free up ${formatBytes(totalSize)}.`,
-          [
-            { text: 'Cancel', style: 'cancel' },
-            {
-              text: 'Delete',
-              style: 'destructive',
-              onPress: () => {
-                executeDeleteModel(model);
-              },
-            },
-          ],
-        ),
-      );
+      setAlertState(buildModelDeleteConfirmation({
+        fileName: model.fileName,
+        totalBytes: totalSize,
+        onDelete: () => { executeDeleteModel(model); },
+      }));
     }
   };
 
@@ -259,7 +280,6 @@ export function useDownloadManager(): UseDownloadManagerResult {
   const handleRepairVision = (item: DownloadItem): void => {
     const model = downloadedModels.find(m => m.id === item.modelId);
     if (!model) return;
-    setRepairingVision(item.modelId, true);
     logger.log('[DownloadDebug] Repair vision requested', {
       modelId: item.modelId,
       currentMmProjPath: item.mmProjPath,
@@ -288,12 +308,26 @@ export function useDownloadManager(): UseDownloadManagerResult {
         });
         setAlertState(showAlert('Repair Failed', e.message));
       })
-      .finally(() => {
-        setRepairingVision(item.modelId, false);
-      });
+      ;
   };
 
-  const isRepairingVision = (modelId: string) => !!repairingVisionIds[modelId];
+  const isRepairingVision = (modelId: string) =>
+    projectorRepairs.some(operation => operation.modelId === modelId);
+
+  const handleCancelVisionRepair = (item: DownloadItem): void => {
+    const operation = projectorRepairs.find(repair => repair.modelId === item.modelId);
+    if (!operation) return;
+    applicationFacade().models.cancelProjectorRepair({ operationId: operation.operationId })
+      .then(outcome => {
+        if (!outcome.ok) throw new Error(modelsFailureMessage(outcome.failure));
+      })
+      .catch(error => {
+        setAlertState(showAlert(
+          'Cancel Failed',
+          error instanceof Error ? error.message : String(error),
+        ));
+      });
+  };
 
   return {
     activeItems,
@@ -306,6 +340,7 @@ export function useDownloadManager(): UseDownloadManagerResult {
     handleResumeDownload,
     handleDeleteItem,
     handleRepairVision,
+    handleCancelVisionRepair,
     isRepairingVision,
     repairDownloadFor,
     totalStorageUsed,

--- a/src/screens/DownloadManagerScreen/useDownloadManager.ts
+++ b/src/screens/DownloadManagerScreen/useDownloadManager.ts
@@ -11,6 +11,7 @@ import {
   hardwareService,
 } from '../../services';
 import {
+  imageDownloadDescriptorFromMetadata,
   modelsFailureMessage,
   visionRepairMessage,
 } from '@offgrid/application';
@@ -30,7 +31,6 @@ import { buildModelDeleteConfirmation } from '../../components/modelDeleteConfir
 import { autoSetupImageCatalogProvider } from '../../services/autoSetupImageCatalogProvider';
 import { mobileImageDownloadSelection } from '../../services/adapters/models/modelControlCatalogPort';
 import { mobileImageDownloadMetadata } from '../../services/modelServices/modelDownloadRequests';
-import { imageDownloadDescriptorFromMetadata } from '@offgrid/models';
 import { isFailedStatus } from '../../utils/downloadStatus';
 
 export interface UseDownloadManagerResult {

--- a/src/screens/ModelsScreen/ImageModelsTab.tsx
+++ b/src/screens/ModelsScreen/ImageModelsTab.tsx
@@ -9,6 +9,7 @@ import { useTheme, useThemedStyles } from '../../theme';
 import { HFImageModel, getVariantLabel } from '../../services/huggingFaceModelBrowser';
 import { ImageModelRecommendation } from '../../types';
 import { isModelDownloadInProgress, modelsFailureMessage } from '@offgrid/application';
+import { createImageDownloadPlan } from '@offgrid/models';
 import { useModelDownloadEntry } from '../../hooks/useModelDownloadsProjection';
 import { isDownloadingStatus, isFailedStatus, isPausedStatus, isQueuedStatus } from '../../utils/downloadStatus';
 import { imageBackendLabel } from '../../utils/imageBackend';
@@ -72,7 +73,8 @@ const ImageModelCard: React.FC<ImageModelCardProps> = ({
 }) => {
   const recommended = isRecommendedModel(model);
   const { isCompatible, incompatibleReason } = getImageModelCompatibility(model, imageRec);
-  const entry = useModelDownloadEntry('image', `image:${model.id}`);
+  const descriptor = hfModelToDescriptor(model);
+  const entry = useModelDownloadEntry('image', createImageDownloadPlan(descriptor).modelId);
   const transfer = imageTransferState(entry, model.size);
   const authorLabel = model._coreml ? 'Core ML' : imageBackendLabel(model.backend);
   const variantLabel = model.variant ? getVariantLabel(model.variant) : undefined;
@@ -86,7 +88,6 @@ const ImageModelCard: React.FC<ImageModelCardProps> = ({
       ));
     }
   };
-  const descriptor = hfModelToDescriptor(model);
   const retryDownload = async () => {
     if (!entry) return;
     const selection = mobileImageDownloadSelection(descriptor);
@@ -130,7 +131,7 @@ const ImageModelCard: React.FC<ImageModelCardProps> = ({
         testID={`image-model-card-${index}`}
         recommended={recommended ? {} : undefined}
         onDownload={transfer.isActive || transfer.hasFailed ? undefined : () => handleDownloadImageModel(descriptor)}
-        onCancel={transfer.isActive ? () => handleCancelImageDownload(model.id) : undefined}
+        onCancel={transfer.isActive ? () => handleCancelImageDownload(descriptor) : undefined}
         onPause={entry && transfer.isDownloading ? () => { controlDownload('pause-download').catch(() => undefined); } : undefined}
         onResume={entry && transfer.isPaused ? () => { controlDownload('resume-download').catch(() => undefined); } : undefined}
         failedState={transfer.hasFailed && entry ? {

--- a/src/screens/ModelsScreen/ImageModelsTab.tsx
+++ b/src/screens/ModelsScreen/ImageModelsTab.tsx
@@ -4,18 +4,21 @@ import { LoadingDots } from '../../components/LoadingDots';
 import Icon from 'react-native-vector-icons/Feather';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import { ModelCard } from '../../components';
+import { showAlert } from '../../components/CustomAlert';
 import { useTheme, useThemedStyles } from '../../theme';
 import { HFImageModel, getVariantLabel } from '../../services/huggingFaceModelBrowser';
 import { ImageModelRecommendation } from '../../types';
-import { isModelDownloadInProgress } from '@offgrid/application';
+import { isModelDownloadInProgress, modelsFailureMessage } from '@offgrid/application';
 import { useModelDownloadEntry } from '../../hooks/useModelDownloadsProjection';
-import { isDownloadingStatus, isPausedStatus, isQueuedStatus } from '../../utils/downloadStatus';
+import { isDownloadingStatus, isFailedStatus, isPausedStatus, isQueuedStatus } from '../../utils/downloadStatus';
 import { imageBackendLabel } from '../../utils/imageBackend';
 import { createStyles } from './styles';
 import { ModelsScreenViewModel } from './useModelsScreen';
 import { ImageFilterBar } from './ImageFilterBar';
 import { BackendFilter, ImageFilterDimension } from './types';
 import { formatBytes, getImageModelCompatibility, hfModelToDescriptor } from './utils';
+import { applicationFacade } from '../../services/applicationFacade';
+import { mobileImageDownloadSelection } from '../../services/adapters/models/modelControlCatalogPort';
 
 type Props = Pick<ModelsScreenViewModel,
   | 'imageSearchQuery' | 'setImageSearchQuery'
@@ -33,6 +36,7 @@ type Props = Pick<ModelsScreenViewModel,
   | 'handleDownloadImageModel' | 'handleCancelImageDownload' | 'loadHFModels'
   | 'clearImageFilters' | 'setUserChangedBackendFilter'
   | 'isRecommendedModel'
+  | 'setAlertState'
 >;
 
 interface ImageModelCardProps {
@@ -42,54 +46,100 @@ interface ImageModelCardProps {
   isRecommendedModel: (model: HFImageModel) => boolean;
   handleDownloadImageModel: Props['handleDownloadImageModel'];
   handleCancelImageDownload: Props['handleCancelImageDownload'];
+  setAlertState: Props['setAlertState'];
+}
+
+function imageTransferState(entry: ReturnType<typeof useModelDownloadEntry>, size: number) {
+  const active = !!entry && isModelDownloadInProgress(entry.status);
+  return {
+    isActive: active,
+    isQueued: isQueuedStatus(entry?.status),
+    isDownloading: isDownloadingStatus(entry?.status),
+    isPaused: isPausedStatus(entry?.status),
+    hasFailed: isFailedStatus(entry?.status),
+    progress: entry && entry.totalBytes > 0 ? entry.bytesDownloaded / entry.totalBytes : 0,
+    bytes: entry ? {
+      downloaded: entry.bytesDownloaded,
+      total: entry.totalBytes || size,
+      bytesPerSecond: entry.bytesPerSecond,
+    } : undefined,
+  };
 }
 
 const ImageModelCard: React.FC<ImageModelCardProps> = ({
   model, index, imageRec,
-  isRecommendedModel, handleDownloadImageModel, handleCancelImageDownload,
+  isRecommendedModel, handleDownloadImageModel, handleCancelImageDownload, setAlertState,
 }) => {
-  const styles = useThemedStyles(createStyles);
   const recommended = isRecommendedModel(model);
   const { isCompatible, incompatibleReason } = getImageModelCompatibility(model, imageRec);
-  const entry = useModelDownloadEntry('image', model.id);
-  const isActive = !!entry && isModelDownloadInProgress(entry.status);
-  const isQueued = isQueuedStatus(entry?.status);
-  const isDownloading = isDownloadingStatus(entry?.status);
-  const isPaused = isPausedStatus(entry?.status);
-  const progressValue = entry && entry.totalBytes > 0
-    ? entry.bytesDownloaded / entry.totalBytes
-    : 0;
+  const entry = useModelDownloadEntry('image', `image:${model.id}`);
+  const transfer = imageTransferState(entry, model.size);
   const authorLabel = model._coreml ? 'Core ML' : imageBackendLabel(model.backend);
-  const variantSuffix = model.variant ? ` \u00B7 ${getVariantLabel(model.variant)}` : '';
+  const variantLabel = model.variant ? getVariantLabel(model.variant) : undefined;
+  const controlDownload = async (type: 'pause-download' | 'resume-download') => {
+    if (!entry) return;
+    const outcome = await applicationFacade().models.control({ type, modelId: entry.downloadId });
+    if (!outcome.ok) {
+      setAlertState(showAlert(
+        type === 'pause-download' ? 'Pause Failed' : 'Resume Failed',
+        modelsFailureMessage(outcome.failure),
+      ));
+    }
+  };
+  const descriptor = hfModelToDescriptor(model);
+  const retryDownload = async () => {
+    if (!entry) return;
+    const selection = mobileImageDownloadSelection(descriptor);
+    if (!selection) {
+      setAlertState(showAlert('Retry Failed', 'The image model source is incomplete.'));
+      return;
+    }
+    const outcome = await applicationFacade().models.control({
+      type: 'retry-download',
+      modelId: entry.downloadId,
+      selection,
+    });
+    if (!outcome.ok) setAlertState(showAlert('Retry Failed', modelsFailureMessage(outcome.failure)));
+  };
+  const removeFailedDownload = async () => {
+    if (!entry) return;
+    const outcome = await applicationFacade().models.control({
+      type: 'clear-download',
+      modelId: entry.downloadId,
+    });
+    if (!outcome.ok) setAlertState(showAlert('Remove Failed', modelsFailureMessage(outcome.failure)));
+  };
   return (
     <View>
-      {recommended && (
-        <View style={styles.recommendedBadge}>
-          <Text style={styles.recommendedBadgeText}>RECOMMENDED</Text>
-        </View>
-      )}
       <ModelCard
         compact
         model={{
           id: model.id,
           name: model.displayName,
           author: authorLabel,
-          description: `${formatBytes(model.size)}${variantSuffix}`,
+          sizeBytes: model.size,
+          facts: [formatBytes(model.size), ...(variantLabel ? [variantLabel] : [])],
         }}
-        isDownloading={isDownloading}
-        isQueued={isQueued}
-        isPaused={isPaused}
-        downloadProgress={progressValue}
-        downloadBytes={entry ? {
-          downloaded: entry.bytesDownloaded,
-          total: entry.totalBytes || model.size,
-          bytesPerSecond: undefined,
-        } : undefined}
+        isDownloading={transfer.isDownloading}
+        isQueued={transfer.isQueued}
+        isPaused={transfer.isPaused}
+        downloadProgress={transfer.progress}
+        downloadBytes={transfer.bytes}
         isCompatible={isCompatible}
         incompatibleReason={incompatibleReason}
         testID={`image-model-card-${index}`}
-        onDownload={isActive ? undefined : () => handleDownloadImageModel(hfModelToDescriptor(model))}
-        onCancel={isActive ? () => handleCancelImageDownload(model.id) : undefined}
+        recommended={recommended ? {} : undefined}
+        onDownload={transfer.isActive || transfer.hasFailed ? undefined : () => handleDownloadImageModel(descriptor)}
+        onCancel={transfer.isActive ? () => handleCancelImageDownload(model.id) : undefined}
+        onPause={entry && transfer.isDownloading ? () => { controlDownload('pause-download').catch(() => undefined); } : undefined}
+        onResume={entry && transfer.isPaused ? () => { controlDownload('resume-download').catch(() => undefined); } : undefined}
+        failedState={transfer.hasFailed && entry ? {
+          errorMessage: entry.reason ?? 'Download failed',
+          bytesDownloaded: entry.bytesDownloaded,
+          totalBytes: entry.totalBytes || model.size,
+          onRetry: () => { retryDownload().catch(error => setAlertState(showAlert('Retry Failed', String(error)))); },
+          onRemove: () => { removeFailedDownload().catch(error => setAlertState(showAlert('Remove Failed', String(error)))); },
+        } : undefined}
       />
     </View>
   );
@@ -137,6 +187,7 @@ interface ImageModelsListProps {
   isRecommendedModel: (model: HFImageModel) => boolean;
   handleDownloadImageModel: Props['handleDownloadImageModel'];
   handleCancelImageDownload: Props['handleCancelImageDownload'];
+  setAlertState: Props['setAlertState'];
   imageSearchQuery: string;
 }
 
@@ -149,7 +200,7 @@ const ImageModelsList: React.FC<ImageModelsListProps> = ({
   hasActiveImageFilters, clearImageFilters, setUserChangedBackendFilter,
   hfModelsLoading, hfModelsError, loadHFModels,
   filteredHFModels, availableHFModels,
-  isRecommendedModel, handleDownloadImageModel, handleCancelImageDownload,
+  isRecommendedModel, handleDownloadImageModel, handleCancelImageDownload, setAlertState,
   imageSearchQuery,
 }) => {
   const { colors } = useTheme();
@@ -243,9 +294,10 @@ const ImageModelsList: React.FC<ImageModelsListProps> = ({
         isRecommendedModel={isRecommendedModel}
         handleDownloadImageModel={handleDownloadImageModel}
         handleCancelImageDownload={handleCancelImageDownload}
+        setAlertState={setAlertState}
       />
     ),
-    [handleCancelImageDownload, handleDownloadImageModel, imageRec, isRecommendedModel],
+    [handleCancelImageDownload, handleDownloadImageModel, imageRec, isRecommendedModel, setAlertState],
   );
 
   const keyExtractor = useCallback(
@@ -283,6 +335,7 @@ export const ImageModelsTab: React.FC<Props> = ({
   handleDownloadImageModel, handleCancelImageDownload, loadHFModels,
   clearImageFilters, setUserChangedBackendFilter,
   isRecommendedModel,
+  setAlertState,
 }) => {
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
@@ -349,8 +402,9 @@ export const ImageModelsTab: React.FC<Props> = ({
         availableHFModels={availableHFModels}
         isRecommendedModel={isRecommendedModel}
         handleDownloadImageModel={handleDownloadImageModel}
-        handleCancelImageDownload={handleCancelImageDownload}
-        imageSearchQuery={imageSearchQuery}
+      handleCancelImageDownload={handleCancelImageDownload}
+      setAlertState={setAlertState}
+      imageSearchQuery={imageSearchQuery}
       />
     </View>
   );

--- a/src/screens/ModelsScreen/ImageModelsTab.tsx
+++ b/src/screens/ModelsScreen/ImageModelsTab.tsx
@@ -8,8 +8,11 @@ import { showAlert } from '../../components/CustomAlert';
 import { useTheme, useThemedStyles } from '../../theme';
 import { HFImageModel, getVariantLabel } from '../../services/huggingFaceModelBrowser';
 import { ImageModelRecommendation } from '../../types';
-import { isModelDownloadInProgress, modelsFailureMessage } from '@offgrid/application';
-import { createImageDownloadPlan } from '@offgrid/models';
+import {
+  createImageDownloadPlan,
+  isModelDownloadInProgress,
+  modelsFailureMessage,
+} from '@offgrid/application';
 import { useModelDownloadEntry } from '../../hooks/useModelDownloadsProjection';
 import { isDownloadingStatus, isFailedStatus, isPausedStatus, isQueuedStatus } from '../../utils/downloadStatus';
 import { imageBackendLabel } from '../../utils/imageBackend';

--- a/src/screens/ModelsScreen/TextModelImportControl.tsx
+++ b/src/screens/ModelsScreen/TextModelImportControl.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { Text, TextInput, TouchableOpacity, View } from 'react-native';
+import Icon from 'react-native-vector-icons/Feather';
+import type { createStyles } from './styles';
+
+interface Props {
+  colors: { primary: string; textMuted: string };
+  styles: ReturnType<typeof createStyles>;
+  isImporting: boolean;
+  importProgress: { fraction: number; fileName: string } | null;
+  onImport: () => void;
+}
+
+/** Text-only placement for the existing text/vision import workflow. */
+export const TextModelImportButton: React.FC<Omit<Props, 'importProgress'>> = ({
+  colors,
+  styles,
+  isImporting,
+  onImport,
+}) => (
+  <TouchableOpacity
+    style={[styles.filterToggle, isImporting && styles.filterToggleActive]}
+    onPress={onImport}
+    disabled={isImporting}
+    accessibilityLabel="Import a local text or vision model"
+    hitSlop={{ top: 4, bottom: 4, left: 4, right: 4 }}
+    testID="import-local-model"
+  >
+    <Icon
+      name="upload"
+      size={14}
+      color={isImporting ? colors.primary : colors.textMuted}
+    />
+  </TouchableOpacity>
+);
+
+interface ToolbarProps extends Omit<Props, 'importProgress'> {
+  searchQuery: string;
+  onSearchQueryChange: (value: string) => void;
+  onSearch: () => void;
+  sortIcon: string;
+  sortActive: boolean;
+  sortChanged: boolean;
+  filterActive: boolean;
+  filterChanged: boolean;
+  onToggleSort: () => void;
+  onToggleFilters: () => void;
+  showImport: boolean;
+}
+
+export const TextModelsToolbar: React.FC<ToolbarProps> = ({
+  colors, styles, searchQuery, onSearchQueryChange, onSearch,
+  sortIcon, sortActive, sortChanged, filterActive, filterChanged,
+  onToggleSort, onToggleFilters, showImport, isImporting, onImport,
+}) => (
+  <View style={styles.searchContainer}>
+    <TextInput
+      style={styles.searchInput}
+      placeholder="Search Hugging Face models..."
+      placeholderTextColor={colors.textMuted}
+      value={searchQuery}
+      onChangeText={onSearchQueryChange}
+      onSubmitEditing={onSearch}
+      returnKeyType="search"
+      testID="search-input"
+    />
+    <TouchableOpacity
+      style={[styles.filterToggle, sortActive && styles.filterToggleActive]}
+      onPress={onToggleSort}
+      hitSlop={{ top: 4, bottom: 4, left: 4, right: 4 }}
+      testID="sort-pill"
+    >
+      <Icon name={sortIcon} size={14} color={sortActive ? colors.primary : colors.textMuted} />
+      {sortChanged && <View style={styles.filterDot} />}
+    </TouchableOpacity>
+    <TouchableOpacity
+      style={[styles.filterToggle, filterActive && styles.filterToggleActive]}
+      onPress={onToggleFilters}
+      hitSlop={{ top: 4, bottom: 4, left: 4, right: 4 }}
+      testID="text-filter-toggle"
+    >
+      <Icon name="sliders" size={14} color={filterActive ? colors.primary : colors.textMuted} />
+      {filterChanged && <View style={styles.filterDot} />}
+    </TouchableOpacity>
+    {showImport && (
+      <TextModelImportButton
+        colors={colors}
+        styles={styles}
+        isImporting={isImporting}
+        onImport={onImport}
+      />
+    )}
+  </View>
+);
+
+export const TextModelImportProgress: React.FC<
+  Pick<Props, 'colors' | 'styles' | 'importProgress'>
+> = ({ colors, styles, importProgress }) => importProgress ? (
+  <View style={styles.importProgressCard}>
+    <View style={styles.importProgressHeader}>
+      <Icon name="file" size={18} color={colors.primary} />
+      <Text style={styles.importProgressText} numberOfLines={1}>
+        Importing {importProgress.fileName}
+      </Text>
+    </View>
+    <View style={styles.imageProgressBar}>
+      <View
+        style={[
+          styles.imageProgressFill,
+          { width: `${Math.round(importProgress.fraction * 100)}%` },
+        ]}
+      />
+    </View>
+    <Text style={styles.importProgressPercent}>
+      {Math.round(importProgress.fraction * 100)}%
+    </Text>
+  </View>
+) : null;

--- a/src/screens/ModelsScreen/TextModelImportControl.tsx
+++ b/src/screens/ModelsScreen/TextModelImportControl.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 /** Text-only placement for the existing text/vision import workflow. */
-export const TextModelImportButton: React.FC<Omit<Props, 'importProgress'>> = ({
+const TextModelImportButton: React.FC<Omit<Props, 'importProgress'>> = ({
   colors,
   styles,
   isImporting,

--- a/src/screens/ModelsScreen/TextModelsTab.tsx
+++ b/src/screens/ModelsScreen/TextModelsTab.tsx
@@ -1,6 +1,6 @@
-import { buildCuratedLiteRTFiles, curatedLiteRTDownloadWarning, getCuratedLiteRTEntry, isModelDownloadInProgress, LITERT_PARENT_ID, liteRTGpuUnsupportedNotice, modelsFailureMessage, stripModelFileExtension } from '@offgrid/application';
+import { buildCuratedLiteRTFiles, curatedLiteRTDownloadWarning, getCuratedLiteRTEntry, LITERT_PARENT_ID, liteRTGpuUnsupportedNotice, modelsFailureMessage, stripModelFileExtension } from '@offgrid/application';
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { View, Text, FlatList, TextInput, RefreshControl, TouchableOpacity, Platform, type ListRenderItemInfo } from 'react-native';
+import { View, Text, FlatList, RefreshControl, TouchableOpacity, Platform, type ListRenderItemInfo } from 'react-native';
 import { LoadingDots } from '../../components/LoadingDots';
 import DeviceInfo from 'react-native-device-info';
 import Icon from 'react-native-vector-icons/Feather';
@@ -10,13 +10,11 @@ import { Card, ModelCard } from '../../components';
 import { AnimatedEntry } from '../../components/AnimatedEntry';
 import { CustomAlert, hideAlert, showAlert } from '../../components/CustomAlert';
 import { useTheme, useThemedStyles } from '../../theme';
-import { needsVisionRepair as checkNeedsVisionRepair } from '../../utils/visionRepair';
 import { CREDIBILITY_LABELS } from '../../constants';
 import { ModelInfo, ModelFile } from '../../types';
 import { createStyles } from './styles';
 import { ModelsScreenViewModel } from './useModelsScreen';
-import { isDownloadingStatus, isFailedStatus, isPausedStatus, isQueuedStatus } from '../../utils/downloadStatus';
-import { makeModelKey } from '../../utils/modelKey';
+import { isDownloadingStatus, isPausedStatus, isQueuedStatus } from '../../utils/downloadStatus';
 import { modelSupportsNpuGpu, isAccelerableQuant } from '../../utils/acceleration';
 import { TextFiltersSection } from './TextFiltersSection';
 import { FilterState, SortOption } from './types';
@@ -26,19 +24,21 @@ import { LITERT_FILE_META, LITERT_RECOMMENDED_MODEL, LITERT_PARENT_RECOMMENDED }
 import { repairDownloadedVisionMetadata } from '../../services/modelServices/modelMetadataRepairCommand';
 import { applicationFacade } from '../../services/applicationFacade';
 import { useModelDownloadsProjection } from '../../hooks/useModelDownloadsProjection';
+import { useModelsProjection } from '../../hooks/useApplicationProjection';
 import { fetchModelFiles } from '../../services/modelCatalogFiles';
 import { huggingFaceService } from '../../services/huggingface';
 import { aggregateTextModelDownloads, buildFileDownloadHandler, modelDownloadMatchesFile } from './modelDownloadProjection';
+import { projectModelFileCardState } from './modelFileCardState';
+import { modelDownloadRepositoryId } from '../../services/startModelDownload';
+import { TextModelImportProgress, TextModelsToolbar } from './TextModelImportControl';
 function hasNonSortFilters(fs: FilterState): boolean {
   return fs.orgs.length > 0 || fs.type !== 'all' || fs.source !== 'all' || fs.size !== 'all' || fs.quant !== 'all';
 }
-
 function getEmptyText(hasSearched: boolean, hasActiveFilters: boolean): string {
   if (!hasSearched) return 'No recommended models available.';
   if (hasActiveFilters) return 'No models match your filters. Try adjusting or clearing them.';
   return 'No models found. Try a different search term.';
 }
-
 type Props = Pick<ModelsScreenViewModel,
   | 'searchQuery' | 'setSearchQuery' | 'isLoading' | 'isRefreshing' | 'hasSearched'
   | 'selectedModel' | 'setSelectedModel' | 'modelFiles' | 'setModelFiles' | 'isLoadingFiles'
@@ -50,8 +50,8 @@ type Props = Pick<ModelsScreenViewModel,
   | 'clearFilters' | 'toggleFilterDimension' | 'toggleOrg'
   | 'setTypeFilter' | 'setSourceFilter' | 'setSizeFilter' | 'setQuantFilter' | 'setSortOption'
   | 'isModelDownloaded' | 'getDownloadedModel' | 'isRepairingVisionModel'
+  | 'isImporting' | 'importProgress' | 'handleImportLocalModel'
 > & { onboarding?: boolean };
-
 type DetailProps = Pick<Props,
   | 'modelFiles' | 'isLoadingFiles' | 'filterState' | 'ramGB' | 'alertState' | 'setAlertState'
   | 'getDownloadedModel' | 'isModelDownloaded' | 'isRepairingVisionModel'
@@ -66,13 +66,8 @@ const ModelDetailView: React.FC<DetailProps> = ({
 }) => {
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
-  // Shared decides which devices lack a LiteRT GPU path; this screen only shows the sentence.
   const liteRTGpuNotice = liteRTGpuUnsupportedNotice({ platform: Platform.OS, deviceModel: DeviceInfo.getModel() });
 
-  // Heal the durable vision flag from the authoritative catalog: this screen KNOWS a model is vision
-  // (its repo ships an mmproj → modelFiles carry mmProjFile), so persist isVisionModel:true onto any
-  // downloaded record that lost it. The Download Manager has no catalog, so the RECORD is the single
-  // source both surfaces read — the wrench then shows consistently (device 2026-07-14).
   useEffect(() => {
     repairDownloadedVisionMetadata({
       modelId: selectedModel.id,
@@ -83,31 +78,23 @@ const ModelDetailView: React.FC<DetailProps> = ({
   }, [selectedModel.id, modelFiles]);
 
   const downloads = useModelDownloadsProjection();
+  const projectorRepairs = useModelsProjection().operations.active.filter(
+    operation => operation.kind === 'projector_repair' && operation.state === 'active',
+  );
 
   const getFileCardState = (item: ModelFile) => {
-    const modelKey = makeModelKey(selectedModel.id, item.name);
-    const entry = downloads.find(row => modelDownloadMatchesFile(row, selectedModel.id, item.name));
-    const downloaded = isModelDownloaded(selectedModel.id, item.name);
-    const downloadedModel = getDownloadedModel(selectedModel.id, item.name);
-    const needsVisionRepair = checkNeedsVisionRepair(downloadedModel, item);
-    const repairingVision = isRepairingVisionModel(`${selectedModel.id}/${item.name}`);
-    const inProgress = entry ? isModelDownloadInProgress(entry.status) : false;
-    const hasFailed = entry ? isFailedStatus(entry.status) : false;
-    let progress = entry && (inProgress || hasFailed || entry.status === 'completed') ? {
-      progress: entry.totalBytes > 0 ? entry.bytesDownloaded / entry.totalBytes : 0,
-      bytesDownloaded: entry.bytesDownloaded,
-      totalBytes: entry.totalBytes,
-      bytesPerSecond: undefined,
-      status: entry.status,
-    } : undefined;
-
-    // For completed downloads, discard if size doesn't match expected
-    if (progress && progress.status === 'completed' && progress.bytesDownloaded < item.size) {
-      progress = undefined;
-    }
-    const canCancel   = inProgress;
-    const errorMessage = hasFailed ? (entry?.reason ?? 'Download failed') : undefined;
-    return { downloadKey: modelKey, progress, downloaded, downloadedModel, needsVisionRepair, repairingVision, canCancel, hasFailed, errorMessage };
+    const repositoryId = modelDownloadRepositoryId(selectedModel.id, item.name);
+    const downloaded = isModelDownloaded(repositoryId, item.name);
+    const downloadedModel = getDownloadedModel(repositoryId, item.name);
+    return projectModelFileCardState({
+      modelId: repositoryId,
+      file: item,
+      downloads,
+      projectorRepairs,
+      downloaded,
+      downloadedModel,
+      locallyRepairing: isRepairingVisionModel(`${selectedModel.id}/${item.name}`),
+    });
   };
 
   const renderFileItem = ({ item, index }: { item: ModelFile; index: number }) => {
@@ -126,14 +113,33 @@ const ModelDetailView: React.FC<DetailProps> = ({
     });
     const liteRTMeta = LITERT_FILE_META[item.name];
     const displayName = liteRTMeta?.displayName ?? stripModelFileExtension(item.name);
-    const recommended = liteRTMeta ? { pillLabel: 'Recommended', highlightText: liteRTMeta.highlight } : undefined;
-    const download = downloads.find(row => modelDownloadMatchesFile(row, selectedModel.id, item.name));
+    const recommended = liteRTMeta ? { highlightText: liteRTMeta.highlight } : undefined;
+    const repositoryId = modelDownloadRepositoryId(selectedModel.id, item.name);
+    const download = downloads.find(row => modelDownloadMatchesFile(row, repositoryId, item.name));
     const retry = async () => {
       if (!download) return;
       const outcome = await applicationFacade().models.retryDownload({ downloadId: download.downloadId });
       if (!outcome.ok) {
         setAlertState(showAlert('Retry Failed', modelsFailureMessage(outcome.failure)));
       }
+    };
+    const controlDownload = async (type: 'pause-download' | 'resume-download') => {
+      if (!download) return;
+      const outcome = await applicationFacade().models.control({ type, modelId: download.downloadId });
+      if (!outcome.ok) setAlertState(showAlert(
+          type === 'pause-download' ? 'Pause Failed' : 'Resume Failed',
+          modelsFailureMessage(outcome.failure),
+        ));
+    };
+    const cancelTransfer = async () => {
+      if (!s.repairOperationId) return handleCancelDownload(s.downloadKey);
+      const outcome = await applicationFacade().models.cancelProjectorRepair({
+        operationId: s.repairOperationId,
+      });
+      if (!outcome.ok) setAlertState(showAlert(
+        'Cancel Failed',
+        modelsFailureMessage(outcome.failure),
+      ));
     };
     const failedState = s.hasFailed && s.errorMessage && download ? {
       errorMessage: s.errorMessage,
@@ -159,9 +165,13 @@ const ModelDetailView: React.FC<DetailProps> = ({
         isRepairingVision={s.repairingVision}
         isCompatible={!fileExceedsBudget(item.size, ramGB)} testID={`file-card-${index}`}
         onDownload={onDownload}
-        onDelete={s.downloaded ? () => handleDeleteModel(`${selectedModel.id}/${item.name}`) : undefined}
+        onDelete={s.downloaded ? () => handleDeleteModel(`${repositoryId}/${item.name}`) : undefined}
         onRepairVision={s.needsVisionRepair && !s.progress && !s.repairingVision ? () => handleRepairMmProj(selectedModel, item) : undefined}
-        onCancel={s.canCancel ? () => handleCancelDownload(s.downloadKey) : undefined}
+        onCancel={s.canCancel ? () => { cancelTransfer().catch(error => {
+          setAlertState(showAlert('Cancel Failed', error instanceof Error ? error.message : String(error)));
+        }); } : undefined}
+        onPause={download && isDownloadingStatus(download.status) ? () => { controlDownload('pause-download').catch(() => undefined); } : undefined}
+        onResume={download && isPausedStatus(download.status) ? () => { controlDownload('resume-download').catch(() => undefined); } : undefined}
         compact
         recommended={recommended}
         supportsAcceleration={isAccelerableQuant(item.quantization) || !!liteRTMeta}
@@ -312,7 +322,8 @@ export const TextModelsTab: React.FC<Props> = (props) => {
     handleSearch, handleRefresh, handleSelectModel, handleDownload, handleRepairMmProj, handleCancelDownload, handleDeleteModel,
     clearFilters, toggleFilterDimension, toggleOrg,
     setTypeFilter, setSourceFilter, setSizeFilter, setQuantFilter, setSortOption,
-    isModelDownloaded, getDownloadedModel, isRepairingVisionModel, onboarding = false,
+    isModelDownloaded, getDownloadedModel, isRepairingVisionModel,
+    isImporting, importProgress, handleImportLocalModel, onboarding = false,
   } = props;
   const hasNonSortActiveFilters = hasNonSortFilters(filterState);
   const currentSort = SORT_OPTIONS.find(o => o.key === filterState.sort) ?? SORT_OPTIONS[0];
@@ -372,7 +383,7 @@ export const TextModelsTab: React.FC<Props> = (props) => {
             compact
             model={model}
             file={file}
-            recommended={{ pillLabel: 'Recommended' }}
+            recommended={{}}
             supportsAcceleration
             testID={`onboarding-litert-model-${index}`}
             onPress={guardedDownload}
@@ -421,36 +432,30 @@ export const TextModelsTab: React.FC<Props> = (props) => {
 
   return (
     <>
-      <View style={styles.searchContainer}>
-        <TextInput
-          style={styles.searchInput}
-          placeholder="Search Hugging Face models..."
-          placeholderTextColor={colors.textMuted}
-          value={searchQuery}
-          onChangeText={setSearchQuery}
-          onSubmitEditing={handleSearch}
-          returnKeyType="search"
-          testID="search-input"
+      <TextModelsToolbar
+        colors={colors}
+        styles={styles}
+        searchQuery={searchQuery}
+        onSearchQueryChange={setSearchQuery}
+        onSearch={handleSearch}
+        sortIcon={currentSort.icon}
+        sortActive={sortToggleActive}
+        sortChanged={isSortActive}
+        filterActive={filterToggleActive}
+        filterChanged={hasNonSortActiveFilters}
+        onToggleSort={() => toggleFilterDimension('sort')}
+        onToggleFilters={() => setTextFiltersVisible(v => !v)}
+        showImport={!onboarding}
+        isImporting={isImporting}
+        onImport={handleImportLocalModel}
+      />
+      {!onboarding && isImporting && (
+        <TextModelImportProgress
+          colors={colors}
+          styles={styles}
+          importProgress={importProgress}
         />
-        <TouchableOpacity
-          style={[styles.filterToggle, sortToggleActive && styles.filterToggleActive]}
-          onPress={() => toggleFilterDimension('sort')}
-          hitSlop={{ top: 4, bottom: 4, left: 4, right: 4 }}
-          testID="sort-pill"
-        >
-          <Icon name={currentSort.icon} size={14} color={sortToggleActive ? colors.primary : colors.textMuted} />
-          {isSortActive && <View style={styles.filterDot} />}
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.filterToggle, filterToggleActive && styles.filterToggleActive]}
-          onPress={() => setTextFiltersVisible(v => !v)}
-          hitSlop={{ top: 4, bottom: 4, left: 4, right: 4 }}
-          testID="text-filter-toggle"
-        >
-          <Icon name="sliders" size={14} color={filterToggleActive ? colors.primary : colors.textMuted} />
-          {hasNonSortActiveFilters && <View style={styles.filterDot} />}
-        </TouchableOpacity>
-      </View>
+      )}
 
       {filterState.expandedDimension === 'sort' && <SortPanel filterState={filterState} setSortOption={setSortOption} styles={styles} colors={colors} />}
 

--- a/src/screens/ModelsScreen/TextModelsTab.tsx
+++ b/src/screens/ModelsScreen/TextModelsTab.tsx
@@ -208,13 +208,13 @@ const ModelDetailView: React.FC<DetailProps> = ({
           <Text style={styles.deviceBannerText}>{liteRTGpuNotice}</Text>
         </Card>
       )}
-      <Text style={styles.sectionTitle}>Available Files</Text>
-      {selectedModel.id !== LITERT_PARENT_ID && (
-        <Text style={styles.sectionSubtitle}>
-          Choose a quantization level. Q4_K_M is recommended for mobile.
-          {modelFiles.some(f => f.mmProjFile) && ' Vision files include mmproj.'}
-        </Text>
-      )}
+      <View style={styles.fileListHeader}><Text style={styles.sectionTitle}>Available Files</Text>
+        {selectedModel.id !== LITERT_PARENT_ID && (
+          <Text style={styles.sectionSubtitle}>
+            Choose a quantization level. Q4_K_M is recommended for mobile.
+            {modelFiles.some(f => f.mmProjFile) && ' Vision files include mmproj.'}
+          </Text>
+        )}</View>
       {isLoadingFiles ? (
         <View style={styles.loadingContainer}><LoadingDots color={colors.primary} size={8} /></View>
       ) : (

--- a/src/screens/ModelsScreen/TranscriptionModelsTab.tsx
+++ b/src/screens/ModelsScreen/TranscriptionModelsTab.tsx
@@ -30,7 +30,6 @@ import { useSttDownloadState } from '../../hooks/useSttDownloadState';
 import { modelsFailureMessage, WHISPER_MODELS } from '@offgrid/application';
 import { createStyles as createModelsScreenStyles } from './styles';
 import logger from '../../utils/logger';
-import { RemoteModelOptionsSection } from '../../components/models/RemoteModelOptionsSection';
 import { useActiveMobileModel } from '../../hooks/useActiveMobileModel';
 import { ModelFailureCard } from '../../components/ModelFailureCard';
 import { reportModelFailure } from '../../services/modelFailureHandler';
@@ -141,12 +140,10 @@ const WhisperCard: React.FC<WhisperCardProps> = ({
 
 interface TranscriptionModelsTabProps {
   showLanguageSelector?: boolean;
-  showRemoteModels?: boolean;
 }
 
 export const TranscriptionModelsTab: React.FC<TranscriptionModelsTabProps> = ({
   showLanguageSelector = true,
-  showRemoteModels = true,
 }) => {
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
@@ -315,10 +312,6 @@ export const TranscriptionModelsTab: React.FC<TranscriptionModelsTabProps> = ({
 
       {showLanguageSelector && (
         <TranscriptionLanguageSelect testID="models-transcription-language" />
-      )}
-
-      {showRemoteModels && (
-        <RemoteModelOptionsSection category="transcription" />
       )}
 
       <Text style={styles.sectionLabel}>English only</Text>

--- a/src/screens/ModelsScreen/imageStyles.ts
+++ b/src/screens/ModelsScreen/imageStyles.ts
@@ -1,11 +1,12 @@
 import { TYPOGRAPHY, SPACING } from '../../constants';
 import type { ThemeColors, ThemeShadows } from '../../theme';
 
-const createImageModelsStylesPart1 = (colors: ThemeColors, _shadows: ThemeShadows) => ({
+const createImageModelsStylesPart1 = (colors: ThemeColors, shadows: ThemeShadows) => ({
   recToggle: {
     padding: 12,
     borderRadius: 12,
     backgroundColor: colors.surface,
+    ...shadows.small,
   },
   recToggleActive: {
     backgroundColor: `${colors.primary}15`,

--- a/src/screens/ModelsScreen/index.tsx
+++ b/src/screens/ModelsScreen/index.tsx
@@ -19,10 +19,10 @@ import type { ModelTab } from './types';
 import { ScreenHeader } from '../../components/ScreenHeader';
 
 const MODEL_TABS: ReadonlyArray<{ key: ModelTab; label: string; testID?: string }> = [
-  { key: 'text', label: 'Text Models' },
-  { key: 'image', label: 'Image Models' },
-  { key: 'transcription', label: 'Transcription Models', testID: 'transcription-models-tab' },
-  { key: 'voice', label: 'Voice Models', testID: 'voice-models-tab' },
+  { key: 'text', label: 'Text' },
+  { key: 'image', label: 'Image' },
+  { key: 'transcription', label: 'Transcription', testID: 'transcription-models-tab' },
+  { key: 'voice', label: 'Speech', testID: 'voice-models-tab' },
 ];
 
 interface ModelsScreenProps {
@@ -115,35 +115,11 @@ export const ModelsScreen: React.FC<ModelsScreenProps> = ({ embedded = false }) 
           />
         </HideWhenEmbedded>
 
-        {/* Import Local File */}
-        <HideWhenEmbedded embedded={embedded}><View>
-          {vm.isImporting && vm.importProgress ? (
-            <View style={styles.importProgressCard}>
-              <View style={styles.importProgressHeader}>
-                <Icon name="file" size={18} color={colors.primary} />
-                <Text style={styles.importProgressText} numberOfLines={1}>
-                  Importing {vm.importProgress.fileName}
-                </Text>
-              </View>
-              <View style={styles.imageProgressBar}>
-                <View style={[styles.imageProgressFill, { width: `${Math.round(vm.importProgress.fraction * 100)}%` }]} />
-              </View>
-              <Text style={styles.importProgressPercent}>
-                {Math.round(vm.importProgress.fraction * 100)}%
-              </Text>
-            </View>
-          ) : (
-            <TouchableOpacity style={styles.importButton} onPress={vm.handleImportLocalModel} testID="import-local-model" disabled={vm.isImporting}>
-              <Icon name="folder-plus" size={20} color={colors.primary} />
-              <Text style={styles.importButtonText}>Import Local File</Text>
-            </TouchableOpacity>
-          )}
-        </View></HideWhenEmbedded>
-
         {/* Tab Bar (horizontally scrollable — four tabs don't fit on a phone) */}
         <ScrollView
           horizontal
           showsHorizontalScrollIndicator={false}
+          style={styles.tabBarFrame}
           contentContainerStyle={styles.tabBar}
         >
           {MODEL_TABS.map(tab => (
@@ -205,6 +181,9 @@ export const ModelsScreen: React.FC<ModelsScreenProps> = ({ embedded = false }) 
           isModelDownloaded={vm.isModelDownloaded}
           getDownloadedModel={vm.getDownloadedModel}
           isRepairingVisionModel={vm.isRepairingVisionModel}
+          isImporting={vm.isImporting}
+          importProgress={vm.importProgress}
+          handleImportLocalModel={vm.handleImportLocalModel}
         />
       )}
 
@@ -241,13 +220,14 @@ export const ModelsScreen: React.FC<ModelsScreenProps> = ({ embedded = false }) 
           clearImageFilters={vm.clearImageFilters}
           setUserChangedBackendFilter={vm.setUserChangedBackendFilter}
           isRecommendedModel={vm.isRecommendedModel}
+          setAlertState={vm.setAlertState}
         />
       )}
 
       {/* Voice Models Tab: pro panel when registered, otherwise an upsell. */}
       {vm.activeTab === 'voice' && (
         VoiceModelsPanel
-          ? <VoiceModelsPanel showRemoteModels={!embedded} />
+          ? <VoiceModelsPanel />
           : <VoiceModelsUpsell onGetPro={() => vm.navigation.navigate('ProDetail')} />
       )}
 
@@ -255,7 +235,6 @@ export const ModelsScreen: React.FC<ModelsScreenProps> = ({ embedded = false }) 
       {vm.activeTab === 'transcription' && (
         <TranscriptionModelsTab
           showLanguageSelector={!embedded}
-          showRemoteModels={!embedded}
         />
       )}
 

--- a/src/screens/ModelsScreen/litertRecommended.ts
+++ b/src/screens/ModelsScreen/litertRecommended.ts
@@ -23,7 +23,6 @@ export const LITERT_RECOMMENDED_MODEL: ModelInfo = {
 };
 
 export const LITERT_PARENT_RECOMMENDED = {
-  pillLabel: 'Recommended',
   chips: ['Vision', 'GPU'],
   // No highlightText — the model description already carries it (rendered commonly).
 };

--- a/src/screens/ModelsScreen/modelFileCardState.ts
+++ b/src/screens/ModelsScreen/modelFileCardState.ts
@@ -1,0 +1,58 @@
+import type { ModelsSnapshot } from '@offgrid/application';
+import type { DownloadedModel, ModelFile } from '../../types';
+import { needsVisionRepair } from '../../utils/visionRepair';
+import { isFailedStatus } from '../../utils/downloadStatus';
+import { makeModelKey } from '../../utils/modelKey';
+import { modelDownloadMatchesFile } from './modelDownloadProjection';
+
+type DownloadEntry = ModelsSnapshot['control']['downloads'][number];
+type Operation = ModelsSnapshot['operations']['active'][number];
+
+interface Input {
+  readonly modelId: string;
+  readonly file: ModelFile;
+  readonly downloads: readonly DownloadEntry[];
+  readonly projectorRepairs: readonly Operation[];
+  readonly downloaded: boolean;
+  readonly downloadedModel?: DownloadedModel;
+  readonly locallyRepairing: boolean;
+}
+
+/** Pure presentation projection for one model-file card. Shared remains the lifecycle owner. */
+export function projectModelFileCardState(input: Input) {
+  const downloadKey = makeModelKey(input.modelId, input.file.name);
+  const entry = input.downloads.find(row =>
+    modelDownloadMatchesFile(row, input.modelId, input.file.name));
+  const repair = input.projectorRepairs.find(
+    operation => operation.modelId === input.downloadedModel?.id,
+  );
+  const inProgress = entry ? ['pending', 'queued', 'preparing', 'running', 'downloading', 'verifying', 'processing', 'retrying'].includes(entry.status) : false;
+  const hasFailed = entry ? isFailedStatus(entry.status) : false;
+  let progress = repair ? {
+    progress: (repair.progress?.percent ?? 0) / 100,
+    bytesDownloaded: repair.progress?.bytesDownloaded ?? 0,
+    totalBytes: repair.progress?.totalBytes ?? input.file.mmProjFile?.size ?? 0,
+    bytesPerSecond: repair.progress?.bytesPerSecond,
+    status: 'downloading',
+  } : entry && (inProgress || hasFailed || entry.status === 'completed') ? {
+    progress: entry.totalBytes > 0 ? entry.bytesDownloaded / entry.totalBytes : 0,
+    bytesDownloaded: entry.bytesDownloaded,
+    totalBytes: entry.totalBytes,
+    bytesPerSecond: entry.bytesPerSecond,
+    status: entry.status,
+  } : undefined;
+  if (progress?.status === 'completed' && progress.bytesDownloaded < input.file.size)
+    progress = undefined;
+  return {
+    downloadKey,
+    progress,
+    downloaded: input.downloaded,
+    downloadedModel: input.downloadedModel,
+    needsVisionRepair: needsVisionRepair(input.downloadedModel, input.file),
+    repairingVision: !!repair || input.locallyRepairing,
+    repairOperationId: repair?.operationId,
+    canCancel: inProgress || !!repair,
+    hasFailed,
+    errorMessage: hasFailed ? (entry?.reason ?? 'Download failed') : undefined,
+  };
+}

--- a/src/screens/ModelsScreen/styles.ts
+++ b/src/screens/ModelsScreen/styles.ts
@@ -186,7 +186,7 @@ const createFilterStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
   },
 });
 
-const createTextModelsStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
+const createTextModelsStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   modelInfoCard: {
     marginHorizontal: SPACING.md,
     marginTop: SPACING.md,
@@ -218,12 +218,17 @@ const createTextModelsStyles = (colors: ThemeColors, _shadows: ThemeShadows) => 
   modelDescription: { ...TYPOGRAPHY.bodySmall, color: colors.text, marginBottom: SPACING.xs },
   modelStats: { flexDirection: 'row' as const, gap: 16 },
   statText: { ...TYPOGRAPHY.meta, color: colors.textMuted },
+  fileListHeader: {
+    backgroundColor: colors.background,
+    paddingBottom: SPACING.md,
+    zIndex: 1,
+    ...shadows.bottom,
+  },
   sectionTitle: { ...TYPOGRAPHY.h3, color: colors.text, paddingHorizontal: SPACING.md, marginBottom: 4 },
   sectionSubtitle: {
     ...TYPOGRAPHY.body,
     color: colors.textSecondary,
     paddingHorizontal: SPACING.md,
-    marginBottom: 16,
   },
   recommendedTitle: { ...TYPOGRAPHY.meta, color: colors.textMuted, marginBottom: SPACING.md },
 });

--- a/src/screens/ModelsScreen/styles.ts
+++ b/src/screens/ModelsScreen/styles.ts
@@ -2,7 +2,7 @@ import { TYPOGRAPHY, SPACING } from '../../constants';
 import type { ThemeColors, ThemeShadows } from '../../theme';
 import { createImageModelsStyles } from './imageStyles';
 
-const createBaseStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
+const createBaseStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   flex1: { flex: 1 },
   backButton: { padding: 4, marginRight: 8 },
   searchContainerNoPadding: { paddingHorizontal: 0 },
@@ -28,9 +28,14 @@ const createBaseStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
     flexDirection: 'row' as const,
     paddingHorizontal: SPACING.md,
     gap: SPACING.md,
+  },
+  tabBarFrame: {
     borderBottomWidth: 1,
     borderBottomColor: colors.border,
+    marginTop: SPACING.md,
     marginBottom: 12,
+    flexGrow: 0,
+    ...shadows.bottom,
   },
   tabItem: { paddingVertical: 10, alignItems: 'center' as const },
   tabText: { ...TYPOGRAPHY.body, color: colors.textMuted },
@@ -47,7 +52,8 @@ const createBaseStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
     flexDirection: 'row' as const,
     alignItems: 'center' as const,
     paddingHorizontal: SPACING.md,
-    paddingBottom: 16,
+    paddingTop: SPACING.xs,
+    paddingBottom: 12,
     gap: 8,
   },
   searchInput: {
@@ -58,23 +64,8 @@ const createBaseStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
     paddingHorizontal: 16,
     paddingVertical: 12,
     color: colors.text,
+    ...shadows.small,
   },
-  importButton: {
-    flexDirection: 'row' as const,
-    alignItems: 'center' as const,
-    justifyContent: 'center' as const,
-    gap: 10,
-    marginHorizontal: SPACING.md,
-    marginTop: 12,
-    marginBottom: 8,
-    paddingVertical: 12,
-    borderWidth: 2,
-    borderStyle: 'dashed' as const,
-    borderColor: `${colors.primary}60`,
-    borderRadius: 12,
-    backgroundColor: `${colors.primary}08`,
-  },
-  importButtonText: { ...TYPOGRAPHY.body, color: colors.primary },
   importProgressCard: {
     marginHorizontal: SPACING.md,
     marginTop: 12,
@@ -124,7 +115,7 @@ const createBaseStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
   emptyText: { color: colors.textSecondary, textAlign: 'center' as const },
 });
 
-const createFilterStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
+const createFilterStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   filterBar: { marginBottom: 4, paddingBottom: 4 },
   filterPillRow: {
     paddingHorizontal: SPACING.md,
@@ -173,7 +164,12 @@ const createFilterStyles = (colors: ThemeColors, _shadows: ThemeShadows) => ({
   filterChipActive: { backgroundColor: `${colors.primary}25`, borderColor: colors.primary },
   filterChipText: { ...TYPOGRAPHY.bodySmall, color: colors.textSecondary },
   filterChipTextActive: { color: colors.primary },
-  filterToggle: { padding: 12, borderRadius: 12, backgroundColor: colors.surface },
+  filterToggle: {
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: colors.surface,
+    ...shadows.small,
+  },
   filterToggleActive: { backgroundColor: `${colors.primary}15` },
   filterDot: {
     position: 'absolute' as const,

--- a/src/screens/ModelsScreen/useImageModels.ts
+++ b/src/screens/ModelsScreen/useImageModels.ts
@@ -31,11 +31,11 @@ import { applicationFacade } from '../../services/applicationFacade';
 import { mobileImageDownloadSelection } from '../../services/adapters/models/modelControlCatalogPort';
 import { getUserFacingDownloadMessage } from '../../utils/downloadErrors';
 import {
+  createImageDownloadPlan,
   filterImageCatalog,
   isRecommendedImageCatalogModel,
   recommendedImageBackendFilter,
 } from '@offgrid/application';
-import { createImageDownloadPlan } from '@offgrid/models';
 
 export function useImageModels(setAlertState: (s: AlertState) => void) {
   const [availableHFModels, setAvailableHFModels] = useState<HFImageModel[]>(

--- a/src/screens/ModelsScreen/useImageModels.ts
+++ b/src/screens/ModelsScreen/useImageModels.ts
@@ -186,48 +186,55 @@ export function useImageModels(setAlertState: (s: AlertState) => void) {
   // Stable identities so a memoized card is not invalidated by every parent render.
   const handleDownloadImageModel = useCallback(
     async (modelInfo: ImageModelDescriptor) => {
-      const start = async () => {
-        const selection = mobileImageDownloadSelection(modelInfo);
-        if (!selection) {
-          setAlertState(showAlert('Download Failed', 'The model source is incomplete.'));
+      try {
+        const start = async () => {
+          const selection = mobileImageDownloadSelection(modelInfo);
+          if (!selection) {
+            setAlertState(showAlert('Download Failed', 'The model source is incomplete.'));
+            return;
+          }
+          const outcome = await applicationFacade().models.control({
+            type: 'queue-download',
+            modelId: `image:${modelInfo.id}`,
+            selection,
+          });
+          if (!outcome.ok) {
+            setAlertState(showAlert(
+              'Download Failed',
+              getUserFacingDownloadMessage(modelsFailureMessage(outcome.failure)),
+            ));
+          }
+        };
+        const facts = modelInfo.backend === 'qnn' && Platform.OS === 'android'
+          ? await hardwareService.getSoCInfo()
+          : undefined;
+        const compatibility = imageDownloadCompatibility(modelInfo, {
+          platform: Platform.OS === 'ios' ? 'ios' : Platform.OS === 'android' ? 'android' : 'other',
+          ...(facts ? { hasNpu: facts.hasNPU, qnnVariant: facts.qnnVariant } : {}),
+        });
+        if (compatibility.status === 'blocked') {
+          setAlertState(showAlert('Incompatible Model', compatibility.message));
           return;
         }
-        const outcome = await applicationFacade().models.control({
-          type: 'queue-download',
-          modelId: `image:${modelInfo.id}`,
-          selection,
-        });
-        if (!outcome.ok) {
-          setAlertState(showAlert(
-            'Download Failed',
-            getUserFacingDownloadMessage(modelsFailureMessage(outcome.failure)),
-          ));
-        }
-      };
-      const facts = modelInfo.backend === 'qnn' && Platform.OS === 'android'
-        ? await hardwareService.getSoCInfo()
-        : undefined;
-      const compatibility = imageDownloadCompatibility(modelInfo, {
-        platform: Platform.OS === 'ios' ? 'ios' : Platform.OS === 'android' ? 'android' : 'other',
-        ...(facts ? { hasNpu: facts.hasNPU, qnnVariant: facts.qnnVariant } : {}),
-      });
-      if (compatibility.status === 'blocked') {
-        setAlertState(showAlert('Incompatible Model', compatibility.message));
-        return;
-      }
-      if (compatibility.status === 'confirmation-required') {
-        setAlertState(showAlert('Incompatible Model', compatibility.message, [
-          { text: 'Cancel', style: 'cancel' },
-          {
-            text: 'Download Anyway', style: 'destructive', onPress: async () => {
-              setAlertState(hideAlert());
-              await start();
+        if (compatibility.status === 'confirmation-required') {
+          setAlertState(showAlert('Incompatible Model', compatibility.message, [
+            { text: 'Cancel', style: 'cancel' },
+            {
+              text: 'Download Anyway', style: 'destructive', onPress: async () => {
+                setAlertState(hideAlert());
+                await start();
+              },
             },
-          },
-        ]));
-        return;
+          ]));
+          return;
+        }
+        await start();
+      } catch (error) {
+        setAlertState(showAlert(
+          'Download Failed',
+          error instanceof Error ? error.message : String(error),
+        ));
       }
-      await start();
     },
     [setAlertState],
   );

--- a/src/screens/ModelsScreen/useImageModels.ts
+++ b/src/screens/ModelsScreen/useImageModels.ts
@@ -35,6 +35,7 @@ import {
   isRecommendedImageCatalogModel,
   recommendedImageBackendFilter,
 } from '@offgrid/application';
+import { createImageDownloadPlan } from '@offgrid/models';
 
 export function useImageModels(setAlertState: (s: AlertState) => void) {
   const [availableHFModels, setAvailableHFModels] = useState<HFImageModel[]>(
@@ -195,7 +196,7 @@ export function useImageModels(setAlertState: (s: AlertState) => void) {
           }
           const outcome = await applicationFacade().models.control({
             type: 'queue-download',
-            modelId: `image:${modelInfo.id}`,
+            modelId: createImageDownloadPlan(modelInfo).modelId,
             selection,
           });
           if (!outcome.ok) {
@@ -240,10 +241,11 @@ export function useImageModels(setAlertState: (s: AlertState) => void) {
   );
 
   const handleCancelImageDownload = useCallback(
-    async (modelId: string) => {
+    async (modelInfo: ImageModelDescriptor) => {
       try {
+        const publicModelId = createImageDownloadPlan(modelInfo).modelId;
         const row = applicationFacade().models.snapshot().control.downloads.find(
-          download => download.modelType === 'image' && download.modelId === modelId,
+          download => download.modelType === 'image' && download.modelId === publicModelId,
         );
         if (!row) return;
         const outcome = await applicationFacade().models.control({

--- a/src/screens/ModelsScreen/useTextModels.ts
+++ b/src/screens/ModelsScreen/useTextModels.ts
@@ -3,8 +3,7 @@ import {
   useCallback,
   useDeferredValue,
   useMemo,
-  useEffect,
-  useRef,
+  useEffect, useRef,
 } from 'react';
 import { Keyboard, BackHandler } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
@@ -475,7 +474,6 @@ export function useTextModels(setAlertState: (s: AlertState) => void) {
   const setSizeFilter = useCallback((size: SizeFilter) => patchFilter({ size }), [patchFilter]);
   const setQuantFilter = useCallback((quant: string) => patchFilter({ quant }), [patchFilter]);
   const setSortOption = useCallback((sort: SortOption) => patchFilter({ sort }), [patchFilter]);
-
   const {
     ramGB,
     deviceRecommendation,
@@ -492,14 +490,11 @@ export function useTextModels(setAlertState: (s: AlertState) => void) {
   return {
     searchQuery, setSearchQuery, isLoading, isRefreshing, setIsRefreshing,
     hasSearched, selectedModel, setSelectedModel, modelFiles, setModelFiles,
-    isLoadingFiles, filterState, setFilterState, textFiltersVisible,
-    setTextFiltersVisible, downloadedModels, hasActiveFilters, ramGB,
-    deviceRecommendation, filteredResults, recommendedAsModelInfo,
-    trendingAsModelInfo, handleSearch, handleSelectModel, handleDownload,
-    handleRepairMmProj, handleCancelDownload, handleDeleteModel,
-    loadDownloadedModels, clearFilters, toggleFilterDimension, toggleOrg,
-    setTypeFilter, setSourceFilter, setSizeFilter, setQuantFilter,
-    setSortOption, isModelDownloaded, getDownloadedModel,
-    isRepairingVisionModel,
+    isLoadingFiles, filterState, setFilterState, textFiltersVisible, setTextFiltersVisible,
+    downloadedModels, hasActiveFilters, ramGB, deviceRecommendation, filteredResults, recommendedAsModelInfo,
+    trendingAsModelInfo, handleSearch, handleSelectModel, handleDownload, handleRepairMmProj,
+    handleCancelDownload, handleDeleteModel, loadDownloadedModels, clearFilters, toggleFilterDimension, toggleOrg,
+    setTypeFilter, setSourceFilter, setSizeFilter, setQuantFilter, setSortOption, isModelDownloaded,
+    getDownloadedModel, isRepairingVisionModel,
   };
 }

--- a/src/screens/ModelsScreen/useTextModels.ts
+++ b/src/screens/ModelsScreen/useTextModels.ts
@@ -36,6 +36,7 @@ import {
 } from './constants';
 import logger from '../../utils/logger';
 import { getUserFacingDownloadMessage } from '../../utils/downloadErrors';
+import { buildModelDeleteConfirmation } from '../../components/modelDeleteConfirmation';
 import { downloadedModelMatchesFile, modelDownloadMatchesFile } from './modelDownloadProjection';
 import {
   catalogModelFiles,
@@ -415,12 +416,23 @@ export function useTextModels(setAlertState: (s: AlertState) => void) {
   }, [modelDownloads, setAlertState]);
 
   const handleDeleteModel = useCallback(
-    async (modelId: string) => {
-      if (!downloadedModels.some(model => model.id === modelId)) return;
-      const outcome = await applicationFacade().models.remove(modelId);
-      if (!outcome.ok) {
-        setAlertState(showAlert('Delete Failed', modelsFailureMessage(outcome.failure)));
-      }
+    (modelId: string) => {
+      const model = downloadedModels.find(candidate => candidate.id === modelId);
+      if (!model) return;
+      const totalSize = hardwareService.getModelTotalSize(model);
+      setAlertState(buildModelDeleteConfirmation({
+        fileName: model.fileName,
+        totalBytes: totalSize,
+        onDelete: () => {
+          applicationFacade().models.remove(modelId).then(outcome => {
+            if (!outcome.ok)
+              setAlertState(showAlert('Delete Failed', modelsFailureMessage(outcome.failure)));
+          }).catch(error => setAlertState(showAlert(
+            'Delete Failed',
+            error instanceof Error ? error.message : String(error),
+          )));
+        },
+      }));
     },
     [downloadedModels, setAlertState],
   );

--- a/src/services/adapters/models/library/modelScanAdapter.ts
+++ b/src/services/adapters/models/library/modelScanAdapter.ts
@@ -15,7 +15,10 @@ import {
   recoveredModelBaseName,
 } from '@offgrid/models';
 import { resolveCoreMLModelDir } from '../../../../utils/coreMLModelUtils';
-import { ensureImageExtractionComplete } from '../../../../utils/imageModelIntegrity';
+import {
+  ensureImageExtractionComplete,
+  validateImageModelDir,
+} from '../../../../utils/imageModelIntegrity';
 import {
   isModelProjectorFile as isMMProjFile,
   pickProjectorForModel as pickMmProjForModel,
@@ -297,6 +300,15 @@ export async function scanForUntrackedImageModels(opts: ScanImageModelsOpts): Pr
     if (totalSize === 0) continue;
 
     const identity = recoveredImageModelIdentity(item.name);
+    // A non-empty directory is not proof of an installed model. An interrupted unzip can leave a
+    // large partial tree here; adopting it makes the durable download journal look completed and
+    // removes its Retry action. Only the platform integrity boundary can confirm that this directory
+    // is an installed image model.
+    const ready = await RNFS.exists(`${item.path}/_ready`);
+    if (!ready) {
+      const integrity = await validateImageModelDir(item.path, identity.backend);
+      if (!integrity.complete) continue;
+    }
     const newModel: ONNXImageModel = {
       // Derived from the directory name and NOTHING else. `Date.now()` meant the same directory
       // adopted twice produced two ids nothing downstream could reconcile, and anything holding the

--- a/src/services/adapters/models/modelControlCatalogPort.ts
+++ b/src/services/adapters/models/modelControlCatalogPort.ts
@@ -104,25 +104,12 @@ async function resolveRepositorySelection(
   };
 }
 
-function imageSourceFileName(model: ImageDownloadDescriptor): string | null {
-  try {
-    const marker = '/resolve/main/';
-    const pathname = new URL(model.downloadUrl).pathname;
-    const index = pathname.indexOf(marker);
-    return index < 0
-      ? null
-      : decodeURIComponent(pathname.slice(index + marker.length));
-  } catch {
-    return null;
-  }
-}
-
 export function mobileImageDownloadSelection(
   model: ImageDownloadDescriptor,
 ): ModelControlDownloadSelection | null {
   const plan = createImageDownloadPlan(model);
   const repositoryId = model.repo ?? model.huggingFaceRepo;
-  const fileName = plan.artifacts[0]?.relativePath ?? imageSourceFileName(model);
+  const fileName = plan.artifacts[0]?.relativePath ?? plan.fileName;
   return repositoryId && fileName
     ? { repositoryId, fileName, metadataJson: plan.metadataJson }
     : null;

--- a/src/services/adapters/models/modelControlCatalogPort.ts
+++ b/src/services/adapters/models/modelControlCatalogPort.ts
@@ -105,8 +105,6 @@ async function resolveRepositorySelection(
 }
 
 function imageSourceFileName(model: ImageDownloadDescriptor): string | null {
-  const plan = createImageDownloadPlan(model);
-  if (plan.artifacts.length > 0) return plan.artifacts[0]?.relativePath ?? null;
   try {
     const marker = '/resolve/main/';
     const pathname = new URL(model.downloadUrl).pathname;
@@ -122,9 +120,12 @@ function imageSourceFileName(model: ImageDownloadDescriptor): string | null {
 export function mobileImageDownloadSelection(
   model: ImageDownloadDescriptor,
 ): ModelControlDownloadSelection | null {
+  const plan = createImageDownloadPlan(model);
   const repositoryId = model.repo ?? model.huggingFaceRepo;
-  const fileName = imageSourceFileName(model);
-  return repositoryId && fileName ? { repositoryId, fileName } : null;
+  const fileName = plan.artifacts[0]?.relativePath ?? imageSourceFileName(model);
+  return repositoryId && fileName
+    ? { repositoryId, fileName, metadataJson: plan.metadataJson }
+    : null;
 }
 
 async function resolveImageSelection(

--- a/src/services/adapters/workspaceContent/projectWorkspaceMessage.ts
+++ b/src/services/adapters/workspaceContent/projectWorkspaceMessage.ts
@@ -36,6 +36,13 @@ function audioFormat(mimeType: string | undefined): 'wav' | 'mp3' | undefined {
   return undefined;
 }
 
+/** React Native accepts remote/content URIs as-is; local files require an explicit file URI. */
+function attachmentUri(stored: string | undefined): string {
+  if (!stored) return '';
+  const resolved = resolveDocumentPath(stored);
+  return resolved.startsWith('/') ? `file://${resolved}` : resolved;
+}
+
 function projectAttachments(record: MessageRecord): MediaAttachment[] | undefined {
   if (typeof record.portable.content === 'string') return undefined;
   const locations = record.local?.contentLocations ?? [];
@@ -43,7 +50,7 @@ function projectAttachments(record: MessageRecord): MediaAttachment[] | undefine
   record.portable.content.forEach((part, index) => {
     if (part.type === 'text') return;
     const location = attachmentLocation(locations, part, index);
-    const uri = location?.uri ? resolveDocumentPath(location.uri) : '';
+    const uri = attachmentUri(location?.uri);
     const common = {
       id: attachmentId(record, part, index),
       uri,

--- a/src/services/startModelDownload.ts
+++ b/src/services/startModelDownload.ts
@@ -1,4 +1,4 @@
-import { modelsFailureMessage } from '@offgrid/application';
+import { getCuratedLiteRTEntry, LITERT_PARENT_ID, modelsFailureMessage } from '@offgrid/application';
 import type { ModelFile } from '../types';
 import { makeModelKey } from '../utils/modelKey';
 import { applicationFacade } from './applicationFacade';
@@ -7,16 +7,23 @@ export interface StartModelDownloadOpts {
   onError?: (error: Error) => void;
 }
 
+/** Resolve a synthetic catalogue family to the repository that owns this artifact. */
+export function modelDownloadRepositoryId(repositoryId: string, fileName: string): string {
+  if (repositoryId !== LITERT_PARENT_ID) return repositoryId;
+  return getCuratedLiteRTEntry(fileName)?.hfRepoId ?? repositoryId;
+}
+
 /** Queue one selected text artifact. Shared owns duplicate admission and completion. */
 export async function startModelDownload(
   repositoryId: string,
   file: ModelFile,
   opts: StartModelDownloadOpts = {},
 ): Promise<void> {
+  const sourceRepositoryId = modelDownloadRepositoryId(repositoryId, file.name);
   const outcome = await applicationFacade().models.control({
     type: 'queue-download',
-    modelId: makeModelKey(repositoryId, file.name),
-    selection: { repositoryId, fileName: file.name },
+    modelId: makeModelKey(sourceRepositoryId, file.name),
+    selection: { repositoryId: sourceRepositoryId, fileName: file.name },
   });
   if (!outcome.ok) {
     opts.onError?.(new Error(modelsFailureMessage(outcome.failure)));

--- a/src/theme/palettes.ts
+++ b/src/theme/palettes.ts
@@ -8,6 +8,7 @@ interface ShadowStyle {
 
 export type ThemeShadows = {
   small: ShadowStyle;
+  bottom: ShadowStyle;
   medium: ShadowStyle;
   large: ShadowStyle;
   glow: ShadowStyle;
@@ -94,6 +95,9 @@ export const SHADOWS_LIGHT: ThemeShadows = {
   small: {
     boxShadow: '0px 1px 8px 0px rgba(0,0,0,0.18)',
   },
+  bottom: {
+    boxShadow: '0px 8px 8px -8px rgba(0,0,0,0.24)',
+  },
   medium: {
     boxShadow: '0px 2px 10px 0px rgba(0,0,0,0.22)',
   },
@@ -109,6 +113,9 @@ export const SHADOWS_LIGHT: ThemeShadows = {
 export const SHADOWS_DARK: ThemeShadows = {
   small: {
     boxShadow: '0px 0px 6px 0px rgba(255,255,255,0.18)',
+  },
+  bottom: {
+    boxShadow: '0px 8px 8px -8px rgba(255,255,255,0.18)',
   },
   medium: {
     boxShadow: '0px 0px 6px 0px rgba(255,255,255,0.20)',


### PR DESCRIPTION
## Outcome
Interrupted Android image model packages remain recoverable instead of being misreported as installed. Mobile presentation imports also follow the Shared Application boundary.

## Root cause
A partial extraction directory was adopted as an installed image model. Shared then removed the durable interrupted download row, so Absolutely Reality appeared to start and then disappeared.

## Verification
- Full related JS suite: 246 suites passed, 1,969 tests passed, 1 skipped
- npm run depcruise
- npx tsc --noEmit
- npm run knip
- Full Mobile test gate passed earlier in this release session, including Android and iOS native tests

Depends on off-grid-ai/shared#15.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved image-model downloads with pause, resume, retry, cancellation, progress details, and clearer failure handling.
  - Added local text-model import controls with search, sorting, filtering, and import progress.
  - Added recovery for interrupted voice-model downloads after app restart.
  - Added vision-repair progress and cancellation controls.

- **Improvements**
  - Updated model cards with compact status layouts, transfer speeds, facts, and recommendation icons.
  - Added clearer model deletion confirmations showing storage to be freed.
  - Refined model tabs, spacing, shadows, and navigation presentation.

- **Bug Fixes**
  - Improved image-model identification and recovery across downloads and relaunches.
  - Corrected attachment path handling and chat layout behavior across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->