### PR TITLE
fix(ios): bound Metro launch fallback

### DIFF
--- a/ios/OffgridMobile/AppDelegate.swift
+++ b/ios/OffgridMobile/AppDelegate.swift
@@ -51,10 +51,93 @@ class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
 
   override func bundleURL() -> URL? {
 #if DEBUG
-    // Debug builds must load from Metro so Fast Refresh stays connected on simulators and devices.
-    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
+    // RCTBundleURLProvider can block scene creation for the full TCP timeout when a device cannot
+    // reach the recorded Metro host. Probe it within a fixed bound. A physical-device build made by
+    // scripts/ios-device.sh contains an embedded bundle for this fallback.
+    let provider = RCTBundleURLProvider.sharedSettings()
+    let (host, port) = Self.metroHostAndPort(provider)
+    if Self.metroAnswers(host: host, port: port, within: 2.0),
+       let metroURL = provider.jsBundleURL(forBundleRoot: "index") {
+      return metroURL
+    }
+
+    let embeddedURL = Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+    NSLog(
+      "[bundle] Metro at %@:%d did not answer within 2s; %@",
+      host,
+      port,
+      embeddedURL == nil
+        ? "no embedded bundle is available"
+        : "loading the embedded bundle"
+    )
+    return embeddedURL
 #else
     Bundle.main.url(forResource: "main", withExtension: "jsbundle")
 #endif
   }
+
+#if DEBUG
+  private final class MetroProbeResult: @unchecked Sendable {
+    private let lock = NSLock()
+    private var metroIsRunning = false
+
+    func markRunning() {
+      lock.lock()
+      metroIsRunning = true
+      lock.unlock()
+    }
+
+    func isRunning() -> Bool {
+      lock.lock()
+      defer { lock.unlock() }
+      return metroIsRunning
+    }
+  }
+
+  private static func metroHostAndPort(_ provider: RCTBundleURLProvider) -> (String, Int) {
+    let bundledLocation = Bundle.main.url(forResource: "ip", withExtension: "txt")
+      .flatMap { try? String(contentsOf: $0, encoding: .utf8) }
+    return resolveMetroHostAndPort(
+      configuredLocation: provider.jsLocation,
+      bundledLocation: bundledLocation)
+  }
+
+  static func resolveMetroHostAndPort(
+    configuredLocation: String?, bundledLocation: String?
+  ) -> (String, Int) {
+    let configured = configuredLocation?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    let bundled = bundledLocation?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    let location = configured.isEmpty ? (bundled.isEmpty ? "localhost" : bundled) : configured
+
+    let normalized = location.contains("://") ? location : "http://\(location)"
+    let components = URLComponents(string: normalized)
+    return (components?.host ?? "localhost", components?.port ?? 8081)
+  }
+
+  private static func metroAnswers(host: String, port: Int, within seconds: TimeInterval) -> Bool {
+    guard let url = URL(string: "http://\(host):\(port)/status") else { return false }
+
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.timeoutIntervalForRequest = seconds
+    configuration.timeoutIntervalForResource = seconds
+    let session = URLSession(configuration: configuration)
+    let done = DispatchSemaphore(value: 0)
+    let result = MetroProbeResult()
+    let task = session.dataTask(with: url) { data, response, _ in
+      if let http = response as? HTTPURLResponse,
+         http.statusCode == 200,
+         let data,
+         String(data: data, encoding: .utf8)?.contains("packager-status:running") == true {
+        result.markRunning()
+      }
+      done.signal()
+    }
+    task.resume()
+    if done.wait(timeout: .now() + seconds + 0.5) == .timedOut {
+      task.cancel()
+    }
+    session.invalidateAndCancel()
+    return result.isRunning()
+  }
+#endif
 }

--- a/ios/OffgridMobileTests/OffgridMobileTests.swift
+++ b/ios/OffgridMobileTests/OffgridMobileTests.swift
@@ -21,6 +21,35 @@ private func makeTempDirectory() -> URL {
   return url
 }
 
+final class MetroBundleResolutionTests: XCTestCase {
+  func testConfiguredMetroHostWinsAndPreservesItsPort() {
+    let endpoint = ReactNativeDelegate.resolveMetroHostAndPort(
+      configuredLocation: "http://100.64.0.8:9090",
+      bundledLocation: "192.168.1.20")
+
+    XCTAssertEqual(endpoint.0, "100.64.0.8")
+    XCTAssertEqual(endpoint.1, 9090)
+  }
+
+  func testBundledHostIsUsedWhenMetroHasNoConfiguredLocation() {
+    let endpoint = ReactNativeDelegate.resolveMetroHostAndPort(
+      configuredLocation: nil,
+      bundledLocation: " 192.168.1.20\n")
+
+    XCTAssertEqual(endpoint.0, "192.168.1.20")
+    XCTAssertEqual(endpoint.1, 8081)
+  }
+
+  func testLocalhostIsTheFinalFallback() {
+    let endpoint = ReactNativeDelegate.resolveMetroHostAndPort(
+      configuredLocation: "",
+      bundledLocation: nil)
+
+    XCTAssertEqual(endpoint.0, "localhost")
+    XCTAssertEqual(endpoint.1, 8081)
+  }
+}
+
 final class BlobChannelInterfaceCandidatesTests: XCTestCase {
   func testUsableKeepsOnlyActiveUnicastInterfacesAndPreservesNames() {
     let candidates = [

--- a/scripts/ios-device.sh
+++ b/scripts/ios-device.sh
@@ -150,6 +150,7 @@ if [ -n "${IOS_PROFILE:-}" ]; then
   xcodebuild -workspace OffgridMobile.xcworkspace -scheme OffgridMobile -configuration Debug \
     -destination "generic/platform=iOS" \
     -derivedDataPath build/device \
+    FORCE_BUNDLING=1 \
     CODE_SIGN_STYLE=Manual \
     DEVELOPMENT_TEAM="$TEAM" \
     PROVISIONING_PROFILE_SPECIFIER="$IOS_PROFILE" \
@@ -161,6 +162,7 @@ else
     -destination "generic/platform=iOS" \
     -derivedDataPath build/device \
     -allowProvisioningUpdates \
+    FORCE_BUNDLING=1 \
     CODE_SIGN_STYLE=Automatic \
     DEVELOPMENT_TEAM="$TEAM" \
     build


### PR DESCRIPTION
## Outcome

iOS launch no longer waits without a bound when the preferred Metro endpoint is unavailable.

## Scope

- Bound the development Metro fallback.
- Keep the fallback in the iOS platform adapter.
- Add focused native coverage.

## Evidence

- Three focused Metro endpoint tests pass.
- The Mobile simulator build passes.
- Production SwiftLint, shell syntax, formatting, and diff checks pass.

## Open gates

- Physical-device verification remains open because the listed iPhones were offline.
- The complete production gate remains open with the stacked recovery baseline.

This PR is draft until the required gates pass.

## Stack

Base: release/computer_use
Next: codex/f2-app-restart