### PR TITLE
fix(stores): block persistence until hydration finishes

### DIFF
--- a/__tests__/unit/utils/hydrationGatedStorage.test.ts
+++ b/__tests__/unit/utils/hydrationGatedStorage.test.ts
@@ -1,0 +1,110 @@
+import type { StateStorage } from 'zustand/middleware';
+import { persist } from 'zustand/middleware';
+import { createStore } from 'zustand/vanilla';
+import { createHydrationGatedStorage } from '../../../src/utils/hydrationGatedStorage';
+
+function memoryStorage(initial: Record<string, string> = {}): StateStorage & {
+  values: Map<string, string>;
+} {
+  const values = new Map(Object.entries(initial));
+  return {
+    values,
+    getItem: async name => values.get(name) ?? null,
+    setItem: async (name, value) => {
+      values.set(name, value);
+    },
+    removeItem: async name => {
+      values.delete(name);
+    },
+  };
+}
+
+describe('hydration-gated storage', () => {
+  it('preserves saved state from writes and removal before hydration', async () => {
+    const saved = JSON.stringify({ state: { selected: 'saved' }, version: 0 });
+    const base = memoryStorage({ settings: saved });
+    const gated = createHydrationGatedStorage<{ selected: string }>(base);
+
+    await gated.storage.setItem('settings', {
+      state: { selected: 'default' },
+      version: 0,
+    });
+    await gated.storage.removeItem('settings');
+
+    expect(await gated.storage.getItem('settings')).toEqual({
+      state: { selected: 'saved' },
+      version: 0,
+    });
+  });
+
+  it('persists changes after hydration completes', async () => {
+    const base = memoryStorage();
+    const gated = createHydrationGatedStorage<{ selected: string }>(base);
+
+    gated.markHydrated();
+    expect(gated.isHydrated()).toBe(true);
+    await gated.storage.setItem('settings', {
+      state: { selected: 'next' },
+      version: 0,
+    });
+    expect(await gated.storage.getItem('settings')).toEqual({
+      state: { selected: 'next' },
+      version: 0,
+    });
+    await gated.storage.removeItem('settings');
+    expect(await gated.storage.getItem('settings')).toBeNull();
+  });
+
+  it('keeps saved state through a delayed hydration and the next store restart', async () => {
+    let releaseRead = () => {};
+    const readBlocked = new Promise<void>(resolve => {
+      releaseRead = resolve;
+    });
+    const base = memoryStorage({
+      settings: JSON.stringify({ state: { selected: 'saved' }, version: 0 }),
+    });
+    const delayedBase: StateStorage = {
+      ...base,
+      getItem: async name => {
+        await readBlocked;
+        return base.getItem(name);
+      },
+    };
+
+    const first = createPersistedSelection(delayedBase);
+    first.store.setState({ selected: 'boot-default' });
+    first.store.persist.clearStorage();
+    releaseRead();
+    await waitForHydration(first.store);
+
+    expect(first.store.getState().selected).toBe('saved');
+    first.store.setState({ selected: 'after-hydration' });
+
+    const restarted = createPersistedSelection(base);
+    await waitForHydration(restarted.store);
+    expect(restarted.store.getState().selected).toBe('after-hydration');
+  });
+});
+
+type Selection = { selected: string };
+
+function createPersistedSelection(base: StateStorage) {
+  const gate = createHydrationGatedStorage<Selection>(base);
+  const store = createStore<Selection>()(
+    persist(() => ({ selected: 'default' }), {
+      name: 'settings',
+      storage: gate.storage,
+      onRehydrateStorage: () => () => gate.markHydrated(),
+    }),
+  );
+  return { gate, store };
+}
+
+function waitForHydration(
+  store: ReturnType<typeof createPersistedSelection>['store'],
+): Promise<void> {
+  if (store.persist.hasHydrated()) return Promise.resolve();
+  return new Promise(resolve =>
+    store.persist.onFinishHydration(() => resolve()),
+  );
+}

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
+import { persist } from 'zustand/middleware';
 import { Platform } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import RNFS from 'react-native-fs';
 import type { RecordProvenance } from '@offgrid/sync';
 import {
@@ -10,6 +9,7 @@ import {
 } from '@offgrid/speech';
 import { REASONING_BUDGET_AUTO } from '@offgrid/models';
 import { APP_CONFIG } from '../constants';
+import { createHydrationGatedStorage } from '../utils/hydrationGatedStorage';
 import {
   VoiceTurnMode,
   DeviceInfo,
@@ -274,6 +274,8 @@ export const selectIsLiteRT = (state: AppState): boolean =>
   state.downloadedModels.find(m => m.id === state.activeModelId)?.engine ===
   'litert';
 
+const appStorage = createHydrationGatedStorage<ReturnType<typeof persistedAppState>>();
+
 export const useAppStore = create<AppState>()(
   persist(
     (set, get) => ({
@@ -457,13 +459,20 @@ export const useAppStore = create<AppState>()(
     }),
     {
       name: 'local-llm-app-storage',
-      storage: createJSONStorage(() => AsyncStorage),
+      storage: appStorage.storage,
+      onRehydrateStorage: () => () => appStorage.markHydrated(),
       merge: (persisted, current) =>
         migratePersistedState(persisted, current, {
           defaultSettings: DEFAULT_SETTINGS,
           documentsPath: RNFS.DocumentDirectoryPath,
         }),
-      partialize: state => ({
+      partialize: persistedAppState,
+    },
+  ),
+);
+
+function persistedAppState(state: AppState) {
+  return {
         themeMode: state.themeMode,
         hasCompletedOnboarding: state.hasCompletedOnboarding,
         onboardingChecklist: state.onboardingChecklist,
@@ -479,16 +488,12 @@ export const useAppStore = create<AppState>()(
         imageGenerationCount: state.imageGenerationCount,
         hasEngagedSharePrompt: state.hasEngagedSharePrompt,
         hasRegisteredPro: state.hasRegisteredPro,
-        // Persisted so an eviction STICKS. Without it every relaunch starts at 'unknown', which grants
-        // access, and a device the owner removed is Pro again for as long as the roster takes to answer -
-        // or forever, if it never does because the app is offline.
+        // Persist eviction so a relaunch cannot grant Pro while the roster is offline.
         proDeviceAdmission: state.proDeviceAdmission,
         devProDisabled: state.devProDisabled,
         proBannerDismissed: state.proBannerDismissed,
         desktopPromoDismissed: state.desktopPromoDismissed,
         proAhaTriggeredBy: state.proAhaTriggeredBy,
         loadedSettings: state.loadedSettings,
-      }),
-    },
-  ),
-);
+  };
+}

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { persist } from 'zustand/middleware';
+import { createHydrationGatedStorage } from '../utils/hydrationGatedStorage';
 
 interface AuthState {
   isEnabled: boolean;
@@ -21,6 +21,9 @@ interface AuthState {
 
 const MAX_FAILED_ATTEMPTS = 5;
 const LOCKOUT_DURATION = 5 * 60 * 1000; // 5 minutes in milliseconds
+
+type PersistedAuthState = Pick<AuthState, 'isEnabled' | 'failedAttempts' | 'lockoutUntil'>;
+const authStorage = createHydrationGatedStorage<PersistedAuthState>();
 
 export const useAuthStore = create<AuthState>()(
   persist(
@@ -86,8 +89,9 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'local-llm-auth-storage',
-      storage: createJSONStorage(() => AsyncStorage),
-      partialize: (state) => ({
+      storage: authStorage.storage,
+      onRehydrateStorage: () => () => authStorage.markHydrated(),
+      partialize: (state): PersistedAuthState => ({
         isEnabled: state.isEnabled,
         failedAttempts: state.failedAttempts,
         lockoutUntil: state.lockoutUntil,

--- a/src/stores/chatPersistence.ts
+++ b/src/stores/chatPersistence.ts
@@ -1,6 +1,11 @@
 import { generateId } from '../utils/generateId';
 import type { Message } from '../types';
 
+export interface PersistedChatState {
+  conversations: unknown[];
+  activeConversationId: string | null;
+}
+
 export const CHAT_STORAGE_VERSION = 2;
 
 export function createPersistedMessage(
@@ -47,16 +52,24 @@ function migrateMessage(message: unknown, version: number): unknown {
 export function migratePersistedChatState(
   persistedState: unknown,
   version: number,
-): unknown {
-  if (version >= CHAT_STORAGE_VERSION || !isRecord(persistedState)) {
-    return persistedState;
+): PersistedChatState {
+  if (
+    !isRecord(persistedState) ||
+    !Array.isArray(persistedState.conversations) ||
+    !(persistedState.activeConversationId === null || typeof persistedState.activeConversationId === 'string')
+  ) {
+    return { conversations: [], activeConversationId: null };
   }
-  const conversations = persistedState.conversations;
-  if (!Array.isArray(conversations)) return persistedState;
+  if (version >= CHAT_STORAGE_VERSION) {
+    return {
+      conversations: persistedState.conversations,
+      activeConversationId: persistedState.activeConversationId,
+    };
+  }
 
   return {
-    ...persistedState,
-    conversations: conversations.map(conversation => {
+    activeConversationId: persistedState.activeConversationId,
+    conversations: persistedState.conversations.map(conversation => {
       if (!isRecord(conversation) || !Array.isArray(conversation.messages)) {
         return conversation;
       }

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,11 +1,11 @@
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { persist } from 'zustand/middleware';
 import { Message, Conversation, GenerationMeta } from '../types';
 import {
   stripStreamingControlTokens,
 } from '../utils/messageContent';
 import { generateId } from '../utils/generateId';
+import { createHydrationGatedStorage } from '../utils/hydrationGatedStorage';
 import {
   finalizeStreamedReply,
   type ReplyEnd,
@@ -16,6 +16,7 @@ import {
   CHAT_STORAGE_VERSION,
   createPersistedMessage,
   migratePersistedChatState,
+  type PersistedChatState,
 } from './chatPersistence';
 import {
   createMessageMutationActions,
@@ -29,7 +30,6 @@ import {
   emitSyncMutation,
   messagePutMutation,
 } from '../services/sync/mutation';
-
 /**
  * The portion of the in-progress stream that is safe to SPEAK in voice mode —
  * never the reasoning/thinking. Models that stream reasoning on a separate
@@ -55,7 +55,6 @@ function speakableStreamingAnswer(
     ? ''
     : streamingMessage;
 }
-
 /** Derive conversation title from the first user message. */
 function deriveTitle(
   currentTitle: string,
@@ -67,7 +66,6 @@ function deriveTitle(
   const truncated = content.slice(0, 50);
   return content.length > 50 ? `${truncated}...` : truncated;
 }
-
 export interface ChatState extends ChatMessageMutationActions {
   conversations: Conversation[];
   activeConversationId: string | null;
@@ -165,7 +163,6 @@ const MODEL_NOT_LOADING = {
   isModelLoading: false,
   loadingModelName: null,
 };
-
 const NO_REPLY_ENDED = { lastReplyEnd: null };
 
 const NO_REPLY_FORMING: StreamingFields = {
@@ -176,6 +173,8 @@ const NO_REPLY_FORMING: StreamingFields = {
   isStreaming: false,
   isThinking: false,
 };
+
+const chatStorage = createHydrationGatedStorage<PersistedChatState>();
 
 export const useChatStore = create<ChatState>()(
   persist(
@@ -488,10 +487,11 @@ export const useChatStore = create<ChatState>()(
     }),
     {
       name: 'local-llm-chat-storage',
-      storage: createJSONStorage(() => AsyncStorage),
+      storage: chatStorage.storage,
+      onRehydrateStorage: () => () => chatStorage.markHydrated(),
       version: CHAT_STORAGE_VERSION,
       migrate: migratePersistedChatState,
-      partialize: state => ({
+      partialize: (state): PersistedChatState => ({
         conversations: state.conversations,
         activeConversationId: state.activeConversationId,
       }),

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -1,12 +1,12 @@
 import { create } from 'zustand';
 import { APP_CONFIG } from '../constants';
-import { persist, createJSONStorage } from 'zustand/middleware';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { persist } from 'zustand/middleware';
 import { Project } from '../types';
 import { generateId } from '../utils/generateId';
 import { ragService } from '../services/rag';
 import { useChatStore } from './chatStore';
 import logger from '../utils/logger';
+import { createHydrationGatedStorage } from '../utils/hydrationGatedStorage';
 import {
   CORE_SYNC_ENTITIES,
   emitSyncMutation,
@@ -28,6 +28,8 @@ interface ProjectState {
   getProject: (id: string) => Project | undefined;
   duplicateProject: (id: string) => Project | null;
 }
+
+type PersistedProjectState = Pick<ProjectState, 'projects'>;
 
 // Default projects as examples
 const DEFAULT_PROJECTS: Project[] = [
@@ -95,6 +97,8 @@ When editing, explain your changes. When brainstorming, offer multiple options.`
     updatedAt: new Date().toISOString(),
   },
 ];
+
+const projectStorage = createHydrationGatedStorage<PersistedProjectState>();
 
 export const useProjectStore = create<ProjectState>()(
   persist(
@@ -182,7 +186,9 @@ export const useProjectStore = create<ProjectState>()(
     }),
     {
       name: 'local-llm-project-storage',
-      storage: createJSONStorage(() => AsyncStorage),
+      storage: projectStorage.storage,
+      onRehydrateStorage: () => () => projectStorage.markHydrated(),
+      partialize: (state): PersistedProjectState => ({ projects: state.projects }),
     },
   ),
 );

--- a/src/stores/remoteServerStore.ts
+++ b/src/stores/remoteServerStore.ts
@@ -6,8 +6,7 @@
  */
 
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { persist } from 'zustand/middleware';
 import {
   RemoteServer,
   RemoteModel,
@@ -16,6 +15,7 @@ import {
 } from '../types';
 import logger from '../utils/logger';
 import { generateId } from '../utils/generateId';
+import { createHydrationGatedStorage } from '../utils/hydrationGatedStorage';
 import {
   testServerConnection,
   testEndpointAndGetModels,
@@ -110,6 +110,8 @@ export function migrateRemoteServerState(
     },
   };
 }
+
+const remoteServerStorage = createHydrationGatedStorage<PersistedRemoteServerState>();
 
 export const useRemoteServerStore = create<RemoteServerState>()(
   persist(
@@ -420,8 +422,9 @@ export const useRemoteServerStore = create<RemoteServerState>()(
       name: 'remote-servers',
       version: 2,
       migrate: migrateRemoteServerState,
-      storage: createJSONStorage(() => AsyncStorage),
-      partialize: state => ({
+      storage: remoteServerStorage.storage,
+      onRehydrateStorage: () => () => remoteServerStorage.markHydrated(),
+      partialize: (state): PersistedRemoteServerState => ({
         servers: state.servers.map(({ apiKey: _apiKey, ...server }) => server),
         activeServerId: state.activeServerId,
         activeRemoteTextModelId: state.activeRemoteTextModelId,

--- a/src/stores/whisperStore.ts
+++ b/src/stores/whisperStore.ts
@@ -1,9 +1,9 @@
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { persist } from 'zustand/middleware';
 import { whisperService, WHISPER_MODELS } from '../services/whisperService';
 import { modelResidencyManager } from '../services/modelResidency';
 import logger from '../utils/logger';
+import { createHydrationGatedStorage } from '../utils/hydrationGatedStorage';
 
 /**
  * Outcome of a whisper load, so callers can tell WHY it didn't load:
@@ -54,6 +54,8 @@ interface WhisperState {
   setTranscriptionLanguage: (language: string) => void;
 }
 
+type PersistedWhisperState = Pick<WhisperState, 'downloadedModelId' | 'transcriptionLanguage'>;
+
 type SetState = (partial: Partial<WhisperState> | ((s: WhisperState) => Partial<WhisperState>)) => void;
 
 /** Set one model's in-flight progress without disturbing other concurrent downloads. */
@@ -70,6 +72,8 @@ function clearProgress(set: SetState, modelId: string): void {
     return { downloadProgressById: next };
   });
 }
+
+const whisperStorage = createHydrationGatedStorage<PersistedWhisperState>();
 
 export const useWhisperStore = create<WhisperState>()(
   persist(
@@ -267,8 +271,9 @@ export const useWhisperStore = create<WhisperState>()(
     }),
     {
       name: 'local-llm-whisper-storage',
-      storage: createJSONStorage(() => AsyncStorage),
-      partialize: (state) => ({
+      storage: whisperStorage.storage,
+      onRehydrateStorage: () => () => whisperStorage.markHydrated(),
+      partialize: (state): PersistedWhisperState => ({
         downloadedModelId: state.downloadedModelId,
         transcriptionLanguage: state.transcriptionLanguage,
       }),

--- a/src/utils/hydrationGatedStorage.ts
+++ b/src/utils/hydrationGatedStorage.ts
@@ -1,0 +1,34 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  createJSONStorage,
+  type PersistStorage,
+  type StateStorage,
+} from 'zustand/middleware';
+
+export interface HydrationGatedStorage<S> {
+  storage: PersistStorage<S>;
+  markHydrated(): void;
+  isHydrated(): boolean;
+}
+
+/** Prevent boot-time defaults from replacing saved state before Zustand finishes hydration. */
+export function createHydrationGatedStorage<S>(
+  base: StateStorage = AsyncStorage,
+): HydrationGatedStorage<S> {
+  let hydrated = false;
+  const json = createJSONStorage<S>(() => base);
+  if (!json) throw new Error('JSON storage is unavailable');
+
+  return {
+    storage: {
+      getItem: name => json.getItem(name),
+      setItem: (name, value) =>
+        hydrated ? json.setItem(name, value) : undefined,
+      removeItem: name => (hydrated ? json.removeItem(name) : undefined),
+    },
+    markHydrated: () => {
+      hydrated = true;
+    },
+    isHydrated: () => hydrated,
+  };
+}


### PR DESCRIPTION
## Outcome

A Mobile restart cannot overwrite or remove saved state before asynchronous hydration finishes. Normal persistence starts after hydration.

## Scope

- Add one hydration-gated storage contract.
- Wire all six persisted Zustand stores to the same contract.
- Keep platform persistence in Mobile.

## Evidence

- Hydration persistence tests pass: 3 of 3.
- Focused ESLint passes.
- The iOS Simulator launched and restarted, and Hermes recorded the hydration gate on both launches.

## Open gates

- Physical-device verification remains open because the listed iPhones were offline.
- Live visual inspection remains open.
- The complete production gate remains open with the stacked recovery baseline.

This PR is draft until the required gates pass.

## Stack

Base: codex/f1-app-launch