### PR TITLE
fix(projects): wait for cleanup before local deletion

### DIFF
--- a/__tests__/unit/stores/projectStore.test.ts
+++ b/__tests__/unit/stores/projectStore.test.ts
@@ -19,6 +19,7 @@ import { useProjectStore } from '../../../src/stores/projectStore';
 
 describe('projectStore', () => {
   beforeEach(() => {
+    mockDeleteProjectDocuments.mockReset().mockResolvedValue(undefined);
     // Reset to default projects
     useProjectStore.setState({
       projects: [
@@ -281,7 +282,7 @@ describe('projectStore', () => {
   // deleteProject
   // ============================================================================
   describe('deleteProject', () => {
-    it('removes the project from the store', () => {
+    it('removes the project from the store', async () => {
       const { createProject, deleteProject } = useProjectStore.getState();
       const project = createProject({
         name: 'To Delete',
@@ -290,13 +291,13 @@ describe('projectStore', () => {
         icon: '#000',
       });
 
-      deleteProject(project.id);
+      await deleteProject(project.id);
 
       const found = useProjectStore.getState().getProject(project.id);
       expect(found).toBeUndefined();
     });
 
-    it('reduces the projects count by one', () => {
+    it('reduces the projects count by one', async () => {
       const { createProject, deleteProject } = useProjectStore.getState();
       const project = createProject({
         name: 'To Delete',
@@ -306,13 +307,13 @@ describe('projectStore', () => {
       });
 
       const beforeCount = useProjectStore.getState().projects.length;
-      deleteProject(project.id);
+      await deleteProject(project.id);
       const afterCount = useProjectStore.getState().projects.length;
 
       expect(afterCount).toBe(beforeCount - 1);
     });
 
-    it('does not affect other projects', () => {
+    it('does not affect other projects', async () => {
       const { createProject, deleteProject } = useProjectStore.getState();
       const p1 = createProject({
         name: 'Keep',
@@ -327,15 +328,15 @@ describe('projectStore', () => {
         icon: '#222',
       });
 
-      deleteProject(p2.id);
+      await deleteProject(p2.id);
 
       const kept = useProjectStore.getState().getProject(p1.id);
       expect(kept?.name).toBe('Keep');
     });
 
-    it('handles deleting non-existent project gracefully', () => {
+    it('handles deleting non-existent project gracefully', async () => {
       const initialCount = useProjectStore.getState().projects.length;
-      useProjectStore.getState().deleteProject('non-existent');
+      await useProjectStore.getState().deleteProject('non-existent');
       expect(useProjectStore.getState().projects.length).toBe(initialCount);
     });
   });
@@ -480,19 +481,22 @@ describe('projectStore', () => {
   // RAG cleanup on delete
   // ============================================================================
   describe('RAG cleanup on deleteProject', () => {
-    it('calls ragService.deleteProjectDocuments when deleting a project', () => {
+    it('calls ragService.deleteProjectDocuments when deleting a project', async () => {
       const { deleteProject } = useProjectStore.getState();
-      deleteProject('default-assistant');
-      expect(mockDeleteProjectDocuments).toHaveBeenCalledWith('default-assistant');
+      await deleteProject('default-assistant');
+      expect(mockDeleteProjectDocuments).toHaveBeenCalledWith(
+        'default-assistant',
+      );
     });
 
-    it('removes the project even if RAG cleanup fails', () => {
+    it('preserves the project and returns a refusal if RAG cleanup fails', async () => {
       mockDeleteProjectDocuments.mockRejectedValueOnce(new Error('DB error'));
       const { deleteProject } = useProjectStore.getState();
       const beforeCount = useProjectStore.getState().projects.length;
-      deleteProject('default-assistant');
+      const outcome = await deleteProject('default-assistant');
       const afterCount = useProjectStore.getState().projects.length;
-      expect(afterCount).toBe(beforeCount - 1);
+      expect(outcome).toEqual({ ok: false, reason: 'DB error' });
+      expect(afterCount).toBe(beforeCount);
     });
   });
 });

--- a/src/screens/ProjectDetailScreen.tsx
+++ b/src/screens/ProjectDetailScreen.tsx
@@ -21,6 +21,7 @@ import { RootStackParamList } from '../navigation/types';
 import { KnowledgeBaseSection } from './ProjectDetailKnowledgeBaseSection';
 import { formatWhen } from '../utils/localTime';
 import { useConversationPreviewLine } from '../hooks/useConversationPreviewLine';
+import { PROJECT_DELETE_FALLBACK_REASON } from '../stores/projectDeleteOutcome';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 type RouteProps = RouteProp<RootStackParamList, 'ProjectDetail'>;
@@ -93,9 +94,18 @@ export const ProjectDetailScreen: React.FC = () => {
           {
             text: 'Delete',
             style: 'destructive',
-            onPress: () => {
-              deleteProject(projectId);
-              navigation.goBack();
+            onPress: async () => {
+              const outcome = await deleteProject(projectId);
+              if (outcome.ok) {
+                navigation.goBack();
+                return;
+              }
+              setAlertState(
+                showAlert(
+                  'Project Not Deleted',
+                  outcome.reason || PROJECT_DELETE_FALLBACK_REASON,
+                ),
+              );
             },
           },
         ],

--- a/src/screens/ProjectsScreen.tsx
+++ b/src/screens/ProjectsScreen.tsx
@@ -24,6 +24,7 @@ import { TYPOGRAPHY, SPACING } from '../constants';
 import { useProjectStore, useChatStore } from '../stores';
 import { Project } from '../types';
 import { RootStackParamList, MainTabParamList } from '../navigation/types';
+import { PROJECT_DELETE_FALLBACK_REASON } from '../stores/projectDeleteOutcome';
 
 type NavigationProp = CompositeNavigationProp<
   BottomTabNavigationProp<MainTabParamList, 'ProjectsTab'>,
@@ -49,21 +50,31 @@ export const ProjectsScreen: React.FC = () => {
   };
 
   const handleDeleteProject = (project: Project) => {
-    setAlertState(showAlert(
-      'Delete Project',
-      `Delete "${project.name}"? This will not delete the chats associated with this project.`,
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Delete',
-          style: 'destructive',
-          onPress: () => {
-            setAlertState(hideAlert());
-            deleteProject(project.id);
+    setAlertState(
+      showAlert(
+        'Delete Project',
+        `Delete "${project.name}"? This will not delete the chats associated with this project.`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Delete',
+            style: 'destructive',
+            onPress: async () => {
+              setAlertState(hideAlert());
+              const outcome = await deleteProject(project.id);
+              if (!outcome.ok) {
+                setAlertState(
+                  showAlert(
+                    'Project Not Deleted',
+                    outcome.reason || PROJECT_DELETE_FALLBACK_REASON,
+                  ),
+                );
+              }
+            },
           },
-        },
-      ]
-    ));
+        ],
+      ),
+    );
   };
 
   const renderRightActions = (project: Project) => (

--- a/src/stores/projectDeleteOutcome.ts
+++ b/src/stores/projectDeleteOutcome.ts
@@ -1,0 +1,15 @@
+export type ProjectDeleteOutcome =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: string };
+
+export const PROJECT_DELETE_FALLBACK_REASON =
+  'This project could not be deleted.';
+
+export function projectDeleteFailure(error: unknown): ProjectDeleteOutcome {
+  const reason =
+    error instanceof Error ? error.message.trim() : String(error).trim();
+  return {
+    ok: false,
+    reason: reason || PROJECT_DELETE_FALLBACK_REASON,
+  };
+}

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -8,6 +8,10 @@ import { useChatStore } from './chatStore';
 import logger from '../utils/logger';
 import { createHydrationGatedStorage } from '../utils/hydrationGatedStorage';
 import {
+  projectDeleteFailure,
+  type ProjectDeleteOutcome,
+} from './projectDeleteOutcome';
+import {
   CORE_SYNC_ENTITIES,
   emitSyncMutation,
   projectPutMutation,
@@ -24,7 +28,7 @@ interface ProjectState {
     id: string,
     updates: Partial<Omit<Project, 'id' | 'createdAt'>>,
   ) => void;
-  deleteProject: (id: string) => void;
+  deleteProject: (id: string) => Promise<ProjectDeleteOutcome>;
   getProject: (id: string) => Project | undefined;
   duplicateProject: (id: string) => Project | null;
 }
@@ -133,16 +137,19 @@ export const useProjectStore = create<ProjectState>()(
         if (project) emitSyncMutation(projectPutMutation(project));
       },
 
-      deleteProject: id => {
+      deleteProject: async id => {
         const projectExists = get().projects.some(project => project.id === id);
-        ragService
-          .deleteProjectDocuments(id)
-          .catch(err =>
-            logger.error(
-              `Failed to delete RAG documents for project ${id}`,
-              err,
-            ),
+        if (!projectExists) return { ok: true };
+
+        try {
+          await ragService.deleteProjectDocuments(id);
+        } catch (error) {
+          logger.error(
+            `Failed to delete RAG documents for project ${id}`,
+            error,
           );
+          return projectDeleteFailure(error);
+        }
         // Cascade: unfile the project's chats so none is left pointing at a project that
         // no longer exists (a dangling projectId isn't re-filable and still tripped the
         // KB-tool injection). The project store owns "what happens on delete" (like RAG
@@ -151,13 +158,12 @@ export const useProjectStore = create<ProjectState>()(
         set(state => ({
           projects: state.projects.filter(project => project.id !== id),
         }));
-        if (projectExists) {
-          emitSyncMutation({
-            entity: CORE_SYNC_ENTITIES.project,
-            entityId: id,
-            kind: 'delete',
-          });
-        }
+        emitSyncMutation({
+          entity: CORE_SYNC_ENTITIES.project,
+          entityId: id,
+          kind: 'delete',
+        });
+        return { ok: true };
       },
 
       getProject: id => {


### PR DESCRIPTION
## Recovered outcome

A project and its chats stay available when Mobile cannot finish knowledge cleanup. Both project delete surfaces now show the refusal reason.

## Scope

- Await the Mobile RAG cleanup before removing project and chat links.
- Return one typed delete outcome from the project store.
- Keep the project and chats on cleanup failure.
- Show the returned reason in the existing Mobile alert surface.

## Passed checks

- Live iOS Simulator flow: opened `Code Review`, confirmed deletion, returned to Projects, and verified that the project was absent.
- Project store checks: 32 passed, including cleanup refusal preservation.
- Focused ESLint passed.
- Full Mobile TypeScript check passed after refreshing the ignored local Shared package output.
- Diff checks passed.

## Open gates

- The iOS Release simulator build fails because the installed `llama.rn` package has no `ios-arm64_x86_64-simulator` XCFramework slice.
- All available physical iPhones are offline, so physical-device proof is open.
- The live cleanup-refusal state and visual inspection are open because this task prohibits Computer Use. Simulator screenshots were captured but not visually inspected.
- No E2E tests were added, as requested.

This PR must remain draft while these required gates are open.