### PR TITLE
fix(tools): consume shared execution limits

### DIFF
--- a/__tests__/unit/services/generationToolLoop.branches.test.ts
+++ b/__tests__/unit/services/generationToolLoop.branches.test.ts
@@ -288,6 +288,48 @@ describe('runToolLoop — Gemma text parsing branches', () => {
 describe('runToolLoop — bounded multi-tool completion', () => {
   beforeEach(resetMocks);
 
+  it('counts every parallel call against one total response budget', async () => {
+    mockAppState.settings.maxToolCalls = 2;
+    mockedGenerateResponseWithTools.mockResolvedValueOnce({
+      fullResponse: '',
+      toolCalls: [0, 1, 2].map(index => ({
+        id: `tc-${index}`,
+        name: 'web_search',
+        arguments: { query: `query-${index}` },
+      })),
+    });
+    const ctx = createContext();
+
+    await runToolLoop(ctx);
+
+    expect(mockExecuteToolCall).toHaveBeenCalledTimes(2);
+    expect(mockAddMessage).toHaveBeenCalledTimes(3);
+    expect(ctx.onFinalResponse).toHaveBeenCalledWith(toolStepLimitNotice(2));
+  });
+
+  it('shows successful tool output when the final model response is empty', async () => {
+    mockAppState.settings.maxToolCalls = 3;
+    mockExecuteToolCall.mockResolvedValue({
+      name: 'web_search',
+      content: 'Found on this device.',
+      durationMs: 1,
+    });
+    mockedGenerateResponseWithTools
+      .mockResolvedValueOnce({
+        fullResponse: '',
+        toolCalls: [
+          { id: 'tc-1', name: 'web_search', arguments: { query: 'result' } },
+        ],
+      })
+      .mockResolvedValueOnce({ fullResponse: '', toolCalls: [] })
+      .mockResolvedValueOnce({ fullResponse: '', toolCalls: [] });
+    const ctx = createContext();
+
+    await runToolLoop(ctx);
+
+    expect(ctx.onFinalResponse).toHaveBeenCalledWith('Found on this device.');
+  });
+
   it('stops after the configured tool steps and preserves the tool context for the next message', async () => {
     mockAppState.settings.maxToolCalls = 3;
     for (let index = 0; index < 3; index += 1) {

--- a/__tests__/unit/services/tools/toolResult.test.ts
+++ b/__tests__/unit/services/tools/toolResult.test.ts
@@ -92,4 +92,14 @@ describe('toolResultModelContent', () => {
     const ok = 'B'.repeat(MAX_TOOL_RESULT_CHARS);
     expect(toolResultModelContent({ name: 't', content: ok, status: 'ok', durationMs: 1 })).toBe(ok);
   });
+
+  it('uses the result budget supplied by the active tool loop', () => {
+    const raw = 'C'.repeat(5000);
+    const text = toolResultModelContent(
+      { name: 'small-window', content: raw, status: 'ok', durationMs: 1 },
+      1000,
+    );
+    expect(text).toMatch(/showing the first 1000 of 5000 characters/);
+    expect(text.length).toBeLessThan(raw.length);
+  });
 });

--- a/src/hooks/useTextGenerationSettings.ts
+++ b/src/hooks/useTextGenerationSettings.ts
@@ -1,5 +1,10 @@
 import { DEFAULT_SETTINGS } from '../stores/appStore';
 import { selectIsLiteRT, useAppStore } from '../stores';
+import {
+  MAX_MAX_TOOL_CALLS,
+  MIN_MAX_TOOL_CALLS,
+  normalizeMaxToolCalls,
+} from '@offgrid/models';
 
 export interface NumericSettingModel {
   key: string;
@@ -68,12 +73,12 @@ export function useTextGenerationSettings() {
     label: 'Maximum Tool Calls',
     description: 'Emergency limit for tool calls in one response',
     value: maxToolCalls,
-    min: 1,
-    max: 100,
+    min: MIN_MAX_TOOL_CALLS,
+    max: MAX_MAX_TOOL_CALLS,
     step: 1,
     decimals: 0,
     onChange: (value: number) =>
-      updateSettings({ maxToolCalls: Math.round(value) }),
+      updateSettings({ maxToolCalls: normalizeMaxToolCalls(value) }),
   } satisfies NumericSettingModel;
 
   const llama = {

--- a/src/services/generationToolLoop.ts
+++ b/src/services/generationToolLoop.ts
@@ -26,14 +26,18 @@ import {
   XML_TOOL_CALL_FUNCTION_MARKER,
   XML_TOOL_CALL_PARAMETER_MARKER,
 } from '../utils/messageContent';
-const DEFAULT_MAX_TOOL_STEPS_PER_RESPONSE = 25;
+import {
+  callsWithinToolBudget,
+  finalResponseFromToolResults,
+  normalizeMaxToolCalls,
+  toolPromptChars,
+  toolResultCharBudget,
+} from '@offgrid/models';
 export const toolStepLimitNotice = (maximum: number): string =>
   `This response reached the ${maximum}-step tool limit, so it stopped. The conversation context is still available. Send another message to continue.`;
 const currentMaxToolSteps = (): number => {
   const configured = useAppStore.getState().settings.maxToolCalls;
-  return Number.isInteger(configured) && configured >= 1 && configured <= 100
-    ? configured
-    : DEFAULT_MAX_TOOL_STEPS_PER_RESPONSE;
+  return normalizeMaxToolCalls(configured);
 };
 // On-device: above this many tools, run a fast routing pass to pick the relevant ones
 // before generating (small models can't fit many schemas in context). Tunable.
@@ -383,9 +387,14 @@ async function executeToolCallSafely(tc: ToolCall): Promise<ToolResult> {
 
 async function executeToolCalls(
   ctx: ToolLoopContext,
-  toolCalls: import('./tools/types').ToolCall[],
-  loopMessages: Message[],
+  input: {
+    toolCalls: import('./tools/types').ToolCall[];
+    loopMessages: Message[];
+    tools: readonly unknown[];
+    successfulResults: string[];
+  },
 ): Promise<number> {
+  const { toolCalls, loopMessages, tools, successfulResults } = input;
   const chatStore = useChatStore.getState();
   let executed = 0;
   for (const tc of toolCalls) {
@@ -409,10 +418,20 @@ async function executeToolCalls(
     ctx.callbacks?.onToolCallStart?.(tc.name, tc.arguments);
     const result = await executeToolCallSafely(tc);
     ctx.callbacks?.onToolCallComplete?.(tc.name, result);
+    const settings = useAppStore.getState().settings;
+    const resultBudget = toolResultCharBudget({
+      contextLength: settings.contextLength,
+      promptChars: toolPromptChars(loopMessages, tools),
+      replyReserveTokens: settings.maxTokens,
+    });
+    const resultContent = toolResultModelContent(result, resultBudget);
+    if (result.status === 'ok' && resultContent.trim()) {
+      successfulResults.push(resultContent);
+    }
     const toolResultMsg: Message = {
       id: `tool-result-${Date.now()}-${tc.id || tc.name}`,
       role: 'tool',
-      content: toolResultModelContent(result),
+      content: resultContent,
       timestamp: Date.now(),
       toolCallId: tc.id,
       toolName: tc.name,
@@ -660,14 +679,25 @@ interface LiteRTToolOutcome {
 
 function buildLiteRTToolCallHandler(
   ctx: ToolLoopContext,
-  conversationId: string,
-  outcome?: LiteRTToolOutcome,
+  input: {
+    conversationId: string;
+    outcome?: LiteRTToolOutcome;
+    initialMessages?: readonly Message[];
+    tools?: readonly unknown[];
+  },
 ) {
+  const {
+    conversationId,
+    outcome,
+    initialMessages = [],
+    tools = [],
+  } = input;
   const maxToolSteps = currentMaxToolSteps();
   const limitNotice = toolStepLimitNotice(maxToolSteps);
   // Per-turn counter: this closure is rebuilt once per generation, so it resets each new
   // message and the native loop reuses it for every tool call within the turn.
   let toolCallCount = 0;
+  const promptMessages: unknown[] = [...initialMessages];
   return async (
     name: string,
     args: Record<string, unknown>,
@@ -695,7 +725,13 @@ function buildLiteRTToolCallHandler(
     // mistake it for a successful answer.
     const result = await executeToolCallSafely(toolCall);
     ctx.callbacks?.onToolCallComplete?.(name, result);
-    const resultContent = toolResultModelContent(result);
+    const settings = useAppStore.getState().settings;
+    const resultBudget = toolResultCharBudget({
+      contextLength: settings.contextLength,
+      promptChars: toolPromptChars(promptMessages, tools),
+      replyReserveTokens: settings.maxTokens,
+    });
+    const resultContent = toolResultModelContent(result, resultBudget);
     const toolCallMsg: Message = {
       id: `tc-${Date.now()}-${name}`,
       role: 'assistant',
@@ -719,6 +755,7 @@ function buildLiteRTToolCallHandler(
     };
     useChatStore.getState().addMessage(conversationId, toolCallMsg);
     useChatStore.getState().addMessage(conversationId, toolResultMsg);
+    promptMessages.push(toolCallMsg, toolResultMsg);
     if (result.status === 'ok') outcome?.results.push(resultContent);
     if (toolCallCount === maxToolSteps) {
       if (outcome) outcome.limitReached = true;
@@ -771,7 +808,12 @@ async function callLiteRTForLoop(
   });
   const outcome: LiteRTToolOutcome = { results: [], limitReached: false };
   const onToolCall = ctx
-    ? buildLiteRTToolCallHandler(ctx, conversationId, outcome)
+    ? buildLiteRTToolCallHandler(ctx, {
+        conversationId,
+        outcome,
+        initialMessages: messages,
+        tools,
+      })
     : undefined;
   const handlers = {
     onToken: (token: string) => onStream?.({ content: token }),
@@ -1088,6 +1130,7 @@ interface ToolLoopState {
   thinkingDoneFired: boolean;
   streamedContent: string;
   reasoningContent: string;
+  successfulToolResults: string[];
 }
 
 function buildStreamHandler(
@@ -1271,6 +1314,7 @@ export async function runToolLoop(
     thinkingDoneFired: false,
     streamedContent: '',
     reasoningContent: '',
+    successfulToolResults: [],
   };
   for (let iteration = 0; iteration < maxToolSteps; iteration++) {
     if (ctx.isAborted()) {
@@ -1320,16 +1364,21 @@ export async function runToolLoop(
       fullResponse,
       toolCalls,
     );
-    const cappedToolCalls = effectiveToolCalls.slice(
-      0,
-      maxToolSteps - totalToolCalls,
+    const cappedToolCalls = callsWithinToolBudget(
+      effectiveToolCalls,
+      totalToolCalls,
+      maxToolSteps,
     );
 
     // No tool calls → model gave a final text response
     if (cappedToolCalls.length === 0) {
       // Empty response with tools — retry once without tools (some models choke on tool schemas).
       // Never after an abort: this retry is a FULL generation, the exact zombie a stop must kill.
-      if (!state.streamedContent && !displayResponse && !ctx.isAborted()) {
+      if (
+        !state.streamedContent.trim() &&
+        !displayResponse.trim() &&
+        !ctx.isAborted()
+      ) {
         state.streamedContent = '';
         state.reasoningContent = '';
         state.firstTokenFired = false;
@@ -1345,7 +1394,14 @@ export async function runToolLoop(
             ctx,
           },
         );
-        emitFinalResponse(ctx, state, fallbackResp);
+        emitFinalResponse(
+          ctx,
+          state,
+          finalResponseFromToolResults(
+            fallbackResp,
+            state.successfulToolResults,
+          ),
+        );
         return { interrupted: false };
       }
       emitFinalResponse(ctx, state, displayResponse);
@@ -1380,11 +1436,12 @@ export async function runToolLoop(
     loopMessages.push(assistantMsg);
     chatStore.addMessage(ctx.conversationId, assistantMsg);
 
-    totalToolCalls += await executeToolCalls(
-      ctx,
-      cappedToolCalls,
+    totalToolCalls += await executeToolCalls(ctx, {
+      toolCalls: cappedToolCalls,
       loopMessages,
-    );
+      tools: effectiveSchemas,
+      successfulResults: state.successfulToolResults,
+    });
 
     if (ctx.isAborted()) {
       return { interrupted: true };

--- a/src/services/tools/toolResult.ts
+++ b/src/services/tools/toolResult.ts
@@ -11,6 +11,12 @@
  * Pure + UI-free so both core and pro depend on it without dragging UI in.
  */
 import type { ToolCall, ToolResult, ToolErrorCategory } from './types';
+import {
+  boundToolResult,
+  MAX_TOOL_RESULT_CHARS,
+} from '@offgrid/models';
+
+export { MAX_TOOL_RESULT_CHARS } from '@offgrid/models';
 
 /** Best-effort classification of a failure from its message (one place this lives). */
 export function classifyToolError(err: unknown): ToolErrorCategory {
@@ -60,23 +66,24 @@ export function normalizeToolResult(call: ToolCall, raw: ToolResult): ToolResult
  * model it was truncated so it doesn't assume it saw everything. This gate is upstream-agnostic — it
  * protects against any oversized result, no matter how the tool is written.
  */
-export const MAX_TOOL_RESULT_CHARS = 24000;
-
 /**
  * The content string the MODEL sees. Never empty; failures and empties are stated
  * explicitly so the model treats them as such instead of inventing an answer.
  */
-export function toolResultModelContent(result: ToolResult): string {
+export function toolResultModelContent(
+  result: ToolResult,
+  maxChars = MAX_TOOL_RESULT_CHARS,
+): string {
   if (result.status === 'error') {
     const cat = result.errorCategory ?? 'internal';
-    return `Tool "${result.name}" failed (${cat}): ${result.error ?? 'unknown error'}. It returned no data — do not assume it succeeded.`;
+    return boundToolResult(
+      result.name,
+      `Tool "${result.name}" failed (${cat}): ${result.error ?? 'unknown error'}. It returned no data — do not assume it succeeded.`,
+      maxChars,
+    );
   }
   if (result.status === 'empty') {
     return `Tool "${result.name}" ran but returned no content.`;
   }
-  if (result.content.length > MAX_TOOL_RESULT_CHARS) {
-    const kept = result.content.slice(0, MAX_TOOL_RESULT_CHARS);
-    return `${kept}\n\n[Tool "${result.name}" result truncated: showing the first ${MAX_TOOL_RESULT_CHARS} of ${result.content.length} characters. The result was too large to send in full — ask a more specific follow-up if you need more.]`;
-  }
-  return result.content;
+  return boundToolResult(result.name, result.content, maxChars);
 }

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -7,7 +7,7 @@ import {
   DEFAULT_SILENCE_AFTER_SPEECH_MS,
   DEFAULT_SPEAKER_DRAIN_MS,
 } from '@offgrid/speech';
-import { REASONING_BUDGET_AUTO } from '@offgrid/models';
+import { DEFAULT_MAX_TOOL_CALLS, REASONING_BUDGET_AUTO } from '@offgrid/models';
 import { APP_CONFIG } from '../constants';
 import { createHydrationGatedStorage } from '../utils/hydrationGatedStorage';
 import {
@@ -230,7 +230,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   systemPrompt: APP_CONFIG.defaultSystemPrompt,
   temperature: 0.7,
   maxTokens: 1024,
-  maxToolCalls: 25,
+  maxToolCalls: DEFAULT_MAX_TOOL_CALLS,
   topP: 0.9,
   repeatPenalty: 1.1,
   contextLength: 4096,


### PR DESCRIPTION
## User outcome

A Mobile tool reply uses the same total call budget and result-size policy as Desktop. Successful tool data remains visible when the model final response is empty.

## Scope

- Consume Shared defaults and normalization in settings and both text engines.
- Count a parallel batch against the total response allowance.
- Bound JS and LiteRT tool results to the room left in the configured model window.
- Preserve successful tool output after an empty JS final response.
- Keep Mobile as a thin consumer. Exclude application migration, workflow machinery, compatibility paths, and unrelated model/RAG migration drift.

## Passed checks

- `npx tsc --noEmit`
- Focused ESLint - zero errors
- Focused Tool execution tests - 38/38 passed
- Metro bundled the current branch and the installed Debug app launched on OGA-A1
- `git diff codex/f3-project-cleanup...HEAD --check`

## Open gates

- The existing rendered Tool execution checks stop before the tool flow because the shared chat harness still looks for the removed `model-item` test ID. Behavioral UI proof remains open.
- User-triggered live Tool execution and visual inspection remain open because Computer Use/CUA is prohibited.
- No E2E tests were added or run, as requested.
- The iOS Release simulator build remains blocked because installed `llama.rn` has no `ios-arm64_x86_64-simulator` XCFramework slice.
- All listed physical iPhones are unavailable.
- Production builds were not run because the live and behavioral UI gates are open.
- The inherited Desktop stack still has existing Shared model/RAG type drift; f3 Desktop hosted CI failed there. f3 Mobile has no hosted CI check, and CodeRabbit passed or skipped because that PR is draft.

This PR must remain draft while these gates are open.