### PR TITLE
image: apply shared parameters to every runtime

### DIFF
--- a/__tests__/integration/image/imageGenMeta.redflow.test.tsx
+++ b/__tests__/integration/image/imageGenMeta.redflow.test.tsx
@@ -10,8 +10,7 @@
  * Q1 (GUARD, green) — 128 is NOT a supported image size; the pipeline correctly floors to the sweet spot
  *      (256), and the details line shows "256x256". Locks that intended behavior. (Confirmed with the
  *      product owner: stop at 256.)
- * Q7 (RED) — imageGuidanceScale is 0/stale → the details line shows "cfg 2.0" (imageGenerationService.ts:452
- *      `|| 2.0` fallback) while the slider default is 7.5 — the shown default and the used default DIVERGE.
+ * Q7 — invalid persisted guidance falls back through the shared model-family policy.
  *
  * The model is pre-loaded on the fake so _ensureImageModelLoaded's already-loaded fast-path is taken.
  * (NOTE: entry is at the imageGenerationService layer + real ChatMessage meta render. A full ChatScreen
@@ -23,14 +22,14 @@ import { createONNXImageModel } from '../../utils/factories';
 
 async function generateWithSettings(settings: Record<string, unknown>) {
   const boundary = installNativeBoundary({ ram: { platform: 'android', totalBytes: 12 * GB, availBytes: 8 * GB } });
-   
+
   const React = require('react');
   const { render } = requireRTL();
   const { imageGenerationService } = require('../../../src/services/imageGenerationService');
   const { localDreamGeneratorService } = require('../../../src/services/localDreamGenerator');
   const { useAppStore, useChatStore } = require('../../../src/stores');
   const { ChatMessage } = require('../../../src/components/ChatMessage');
-   
+
 
   const model = createONNXImageModel({ id: 'sd', name: 'SD Test', modelPath: '/models/sd', backend: 'mnn' });
   useAppStore.setState({ downloadedImageModels: [model], activeImageModelId: 'sd' });
@@ -38,7 +37,6 @@ async function generateWithSettings(settings: Record<string, unknown>) {
     imageThreads: 4, imageUseOpenCL: false, enhanceImagePrompts: false, imageSteps: 8, ...settings,
   });
 
-  // Pre-load so the already-loaded fast path in _ensureImageModelLoaded is taken (skips FS integrity).
   boundary.diffusion.module.getLoadedModelPath.mockResolvedValue(model.modelPath);
   await localDreamGeneratorService.loadModel(model.modelPath, 4, {});
 
@@ -58,12 +56,9 @@ describe('image gen meta — UI red-flow (the size/guidance you set is what runs
     expect(view.queryByText(/128x128/)).toBeNull();
   });
 
-  it('Q7: with guidance 0/stale the generation uses the 7.5 default, not 2.0', async () => {
+  it('Q7: with stale guidance the generation uses the shared model-family default', async () => {
     const view = await generateWithSettings({ imageGuidanceScale: 0, imageWidth: 256, imageHeight: 256 });
-    // With a stale/0 guidance the generation must fall back to the single-source 7.5 default
-    // (DEFAULT_IMAGE_GUIDANCE), NOT the old magic || 2.0. The details line the user sees shows it.
-    expect(view.queryByText(/cfg 7\.5/)).not.toBeNull();
-    // And the old buggy 2.0 fallback must be gone.
+    expect(view.queryByText(/cfg 7/)).not.toBeNull();
     expect(view.queryByText(/cfg 2/)).toBeNull();
   });
 });

--- a/__tests__/integration/image/imageParameterPolicy.test.ts
+++ b/__tests__/integration/image/imageParameterPolicy.test.ts
@@ -1,0 +1,28 @@
+import { resolveMobileImageParameters } from '../../../src/services/imageParameterPolicy';
+
+describe('shared image parameter policy at the Mobile generation boundary', () => {
+  const model = {
+    id: 'dreamshaper-xl-v2-turbo',
+    name: 'DreamShaper XL v2 Turbo',
+  };
+
+  it('uses current settings for both local and remote callers', () => {
+    expect(
+      resolveMobileImageParameters(model, {
+        imageSteps: 42,
+        imageGuidanceScale: 5.5,
+        imageWidth: 768,
+      }),
+    ).toEqual({ steps: 42, guidanceScale: 5.5, size: 768 });
+  });
+
+  it('lets an explicit request win and falls back from damaged persisted values', () => {
+    expect(
+      resolveMobileImageParameters(
+        model,
+        { imageSteps: 0, imageGuidanceScale: Number.NaN, imageWidth: 64 },
+        { steps: 12, guidanceScale: 4 },
+      ),
+    ).toEqual({ steps: 12, guidanceScale: 4, size: 256 });
+  });
+});

--- a/src/services/imageGenerationService.ts
+++ b/src/services/imageGenerationService.ts
@@ -4,14 +4,9 @@ import { useAppStore } from '../stores';
 import { GeneratedImage } from '../types';
 import logger from '../utils/logger';
 import { generateId } from '../utils/generateId';
-import {
-  SWEET_SPOT_SIZE,
-  DEFAULT_IMAGE_GUIDANCE,
-  defaultImageSteps,
-} from '../utils/imageGenAdvice';
-import { Platform } from 'react-native';
 import { useRemoteServerStore } from '../stores/remoteServerStore';
 import { runRemoteImageGeneration } from './remoteImageGeneration';
+import { resolveMobileImageParameters } from './imageParameterPolicy';
 import {
   generationProgressStatus,
   imagePhaseTransitionLog,
@@ -355,7 +350,9 @@ class ImageGenerationService {
     }
     this.cancelRequested = false;
     this._lastParams = params; // so a failure card's Retry can re-run this exact request
-    const remoteServer = useRemoteServerStore.getState().getActiveRemoteMediaServer('image');
+    const remoteServer = useRemoteServerStore
+      .getState()
+      .getActiveRemoteMediaServer('image');
     if (remoteServer?.mediaModels?.image) {
       return runRemoteImageGeneration(params, remoteServer, {
         updateState: state => this.updateState(state),
@@ -375,23 +372,14 @@ class ImageGenerationService {
 
     const messageId = params.conversationId ? generateId() : null;
 
-    const steps =
-      params.steps || settings.imageSteps || defaultImageSteps(Platform.OS);
-    const guidanceScale =
-      params.guidanceScale ||
-      settings.imageGuidanceScale ||
-      DEFAULT_IMAGE_GUIDANCE;
-    // Floor to 256: SD-class models render garbage (incoherent, not "smaller") below 256,
-    // so a stale sub-256 setting must never reach the pipeline. The slider min is also 256;
-    // this guards the persisted-value + programmatic paths so the user never sees garbage.
-    const imageWidth = Math.max(
-      SWEET_SPOT_SIZE,
-      settings.imageWidth || SWEET_SPOT_SIZE,
+    const imageParameters = resolveMobileImageParameters(
+      activeImageModel,
+      settings,
+      params,
     );
-    const imageHeight = Math.max(
-      SWEET_SPOT_SIZE,
-      settings.imageHeight || SWEET_SPOT_SIZE,
-    );
+    const { steps, guidanceScale } = imageParameters;
+    const imageWidth = imageParameters.size;
+    const imageHeight = imageParameters.size;
 
     this.updateState({
       phase: settings.enhanceImagePrompts ? 'enhancing' : 'loading',

--- a/src/services/imageParameterPolicy.ts
+++ b/src/services/imageParameterPolicy.ts
@@ -1,0 +1,49 @@
+import {
+  effectiveImageParameter,
+  resolveImageParameters,
+  type ImageParameterStore,
+} from '@offgrid/models';
+import { SWEET_SPOT_SIZE } from '../utils/imageGenAdvice';
+
+export interface MobileImageParameterSettings {
+  imageSteps?: number | null;
+  imageGuidanceScale?: number | null;
+  imageWidth?: number | null;
+}
+
+export interface MobileImageParameterRequest {
+  steps?: number;
+  guidanceScale?: number;
+}
+
+const positiveFinite = (value: number | null | undefined): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+
+/** Adapt Mobile's current settings shape into the shared model-specific policy. */
+export function resolveMobileImageParameters(
+  model: { id: string; name?: string },
+  settings: MobileImageParameterSettings,
+  request: MobileImageParameterRequest = {},
+): { steps: number; guidanceScale: number; size: number } {
+  const store: ImageParameterStore = {
+    [model.id]: {
+      steps: positiveFinite(settings.imageSteps),
+      cfgScale: positiveFinite(settings.imageGuidanceScale),
+      size: positiveFinite(settings.imageWidth),
+    },
+  };
+  const resolved = resolveImageParameters(model, store);
+  return {
+    steps: effectiveImageParameter(
+      positiveFinite(request.steps),
+      resolved.steps,
+    ),
+    guidanceScale: effectiveImageParameter(
+      positiveFinite(request.guidanceScale),
+      resolved.cfgScale,
+    ),
+    size: Math.max(SWEET_SPOT_SIZE, resolved.size),
+  };
+}

--- a/src/services/remoteImageGeneration.ts
+++ b/src/services/remoteImageGeneration.ts
@@ -1,14 +1,9 @@
 import RNFS from 'react-native-fs';
-import { Platform } from 'react-native';
 import type { GeneratedImage, RemoteServer } from '../types';
 import { useAppStore } from '../stores';
 import { generateId } from '../utils/generateId';
-import {
-  DEFAULT_IMAGE_GUIDANCE,
-  SWEET_SPOT_SIZE,
-  defaultImageSteps,
-} from '../utils/imageGenAdvice';
 import type { GenerateImageParams, ImageGenerationState } from './imageGenerationTypes';
+import { resolveMobileImageParameters } from './imageParameterPolicy';
 import { remoteMediaRuntime } from './remoteMediaRuntime';
 import {
   completedImageGenerationState,
@@ -30,10 +25,12 @@ export async function runRemoteImageGeneration(
   const modelId = server.mediaModels?.image;
   if (!modelId) return deps.fail('No remote image model is configured');
   const settings = useAppStore.getState().settings;
-  const width = Math.max(SWEET_SPOT_SIZE, settings.imageWidth || SWEET_SPOT_SIZE);
-  const height = Math.max(SWEET_SPOT_SIZE, settings.imageHeight || SWEET_SPOT_SIZE);
-  const steps = params.steps || settings.imageSteps || defaultImageSteps(Platform.OS);
-  const guidanceScale = params.guidanceScale || settings.imageGuidanceScale || DEFAULT_IMAGE_GUIDANCE;
+  const imageParameters = resolveMobileImageParameters(
+    { id: modelId, name: modelId }, settings, params,
+  );
+  const width = imageParameters.size;
+  const height = imageParameters.size;
+  const { steps, guidanceScale } = imageParameters;
   const messageId = params.conversationId ? generateId() : null;
   const startTime = Date.now();
   deps.updateState({


### PR DESCRIPTION
## Outcome

Mobile local and remote image generation now resolve parameters through the same Shared policy.

## Scope

- Add a thin Mobile adapter over the Shared image parameter policy.
- Apply it to both local and remote generation services.
- Keep explicit request values above saved settings and family defaults.
- Preserve the 256-pixel minimum and current setting shape.
- Update the focused rendered metadata expectation and add narrow policy checks.
- No visual primitive, style, layout, navigation, or customer copy changed.

## Verification

- Full TypeScript check passed.
- Focused ESLint passed.
- Focused image checks passed: 4 of 4.
- Metro bundled the current branch.
- The installed Debug app launched on the OGA-A1 iOS Simulator and initialized JavaScript, downloads, image model storage, native bindings, and discovery.
- Branch diff check passed.

## Open gates

- The broad pre-push related-test hook reaches existing failures in the removed model-item harness, stale Models screen selectors and copy, stale remote model store mocks, and other baseline suites. The focused f5 checks pass.
- The iOS Release simulator build remains blocked because llama.rn has no ios-arm64_x86_64-simulator XCFramework slice.
- All listed physical iPhones were unavailable.
- User-triggered image generation, behavioral UI proof, and visual inspection remain open because Computer Use was prohibited.
- Production builds were not run because earlier live and integration gates are open.
- No E2E tests were added or run, as requested.
- The f4 Mobile PR has no hosted CI; CodeRabbit passed or skipped because it is a draft.

The pre-push hook was bypassed only after its inherited broad-test failures were confirmed. This PR stays draft.