### PR TITLE
feat(models): add MiniCPM5 to mobile catalog

### DIFF
--- a/__tests__/rntl/components/ModelCard.test.tsx
+++ b/__tests__/rntl/components/ModelCard.test.tsx
@@ -418,6 +418,28 @@ describe('ModelCard', () => {
       expect(queryByText('Verified')).toBeNull();
       expect(queryByText(/Unsloth/)).toBeTruthy();
     });
+
+    it('shows the verified icon instead of Official text for official models', () => {
+      const { getByLabelText, queryByText } = render(
+        <ModelCard
+          model={{
+            ...baseModel,
+            author: 'OpenBMB',
+            credibility: {
+              source: 'official',
+              isOfficial: true,
+              isVerifiedQuantizer: false,
+              verifiedBy: 'OpenBMB',
+            },
+          }}
+          compact={true}
+        />
+      );
+
+      expect(getByLabelText('Verified')).toBeTruthy();
+      expect(queryByText('Official')).toBeNull();
+      expect(queryByText(/OpenBMB/)).toBeTruthy();
+    });
   });
 
   // ============================================================================

--- a/__tests__/rntl/screens/ModelsScreen.test.tsx
+++ b/__tests__/rntl/screens/ModelsScreen.test.tsx
@@ -565,9 +565,9 @@ describe('ModelsScreen', () => {
       }
     });
 
-    it('recommended models have editorial ordering with Gemma 4 first', () => {
+    it('recommended models have editorial ordering with MiniCPM5 first', () => {
       const { RECOMMENDED_MODELS } = require('../../../src/constants');
-      expect(RECOMMENDED_MODELS[0].id).toContain('gemma-4');
+      expect(RECOMMENDED_MODELS[0].id).toBe('openbmb/MiniCPM5-2B-GGUF');
     });
 
     it('MODEL_ORGS contains expected organizations', () => {

--- a/__tests__/unit/screens/ModelsScreen/trendingSelection.test.ts
+++ b/__tests__/unit/screens/ModelsScreen/trendingSelection.test.ts
@@ -135,8 +135,8 @@ describe('trendingAsModelInfo — family best-fit selection', () => {
 
     const { result } = renderHook(() => useTextModels(setAlertState));
 
-    // There are 2 families (gemma4, qwen35), so at most 2 models
-    expect(result.current.trendingAsModelInfo.length).toBeLessThanOrEqual(2);
+    // There are 3 families (MiniCPM5, Gemma 4, Qwen 3.5), so one model from each is shown.
+    expect(result.current.trendingAsModelInfo).toHaveLength(3);
 
     // Each returned model ID belongs to one of the trending families
     const { TRENDING_MODEL_IDS } = require('../../../../src/constants');

--- a/src/components/ModelCardContent.tsx
+++ b/src/components/ModelCardContent.tsx
@@ -73,10 +73,11 @@ export const DenseModelCardContent: React.FC<DenseModelCardContentProps> = ({
     supportsAcceleration ? 'NPU/GPU' : undefined,
     incompatibleReason,
   ].filter((value): value is string => !!value);
-  const isVerified = credibilitySource === 'verified-quantizer';
+  const hasVerifiedMark =
+    credibilitySource === 'verified-quantizer' || credibilitySource === 'official';
   const sourceLabels = [
     model.author,
-    isVerified ? undefined : credibilityLabel,
+    hasVerifiedMark ? undefined : credibilityLabel,
     recommended?.pillLabel ?? (isTrending ? 'Trending' : undefined),
   ].filter((value): value is string => !!value);
 
@@ -85,7 +86,7 @@ export const DenseModelCardContent: React.FC<DenseModelCardContentProps> = ({
       <View style={styles.denseTitleRow}>
         <Text style={styles.denseName} numberOfLines={1}>{model.name}</Text>
         <View style={styles.denseSourceGroup}>
-          {isVerified && (
+          {hasVerifiedMark && (
             <MaterialIcon
               name="verified"
               size={12}

--- a/src/constants/models.ts
+++ b/src/constants/models.ts
@@ -11,9 +11,20 @@ export const MODEL_RECOMMENDATIONS = {
   ],
 };
 
-// Curated list of recommended models for mobile (updated Apr 2026)
-// Ordered editorially: Gemma 4 featured first, then Qwen 3.5, then others.
+// Curated list of recommended models for mobile (updated Sep 2026)
+// Ordered editorially: MiniCPM5 featured first, then Gemma 4, Qwen 3.5, and others.
 export const RECOMMENDED_MODELS = [
+  // --- MiniCPM5 (featured) ---
+  {
+    id: 'openbmb/MiniCPM5-2B-GGUF',
+    name: 'MiniCPM5 2B',
+    params: 2,
+    description: 'Strong coding, reasoning, and tool use with 128K context',
+    minRam: 4,
+    type: 'text' as const,
+    org: 'openbmb',
+    isNew: true,
+  },
   // --- Gemma 4 (featured) ---
   {
     id: 'unsloth/gemma-4-E2B-it-GGUF',
@@ -126,6 +137,7 @@ export const RECOMMENDED_MODELS = [
 
 // Trending model families — one best-fit per family is shown as "trending"
 export const TRENDING_FAMILIES: Record<string, string[]> = {
+  minicpm5: ['openbmb/MiniCPM5-2B-GGUF'],
   gemma4: ['unsloth/gemma-4-E2B-it-GGUF', 'unsloth/gemma-4-E4B-it-GGUF'],
   qwen35: ['unsloth/Qwen3.5-0.8B-GGUF', 'unsloth/Qwen3.5-2B-GGUF', 'unsloth/Qwen3.5-9B-GGUF'],
 };
@@ -134,6 +146,7 @@ export const TRENDING_MODEL_IDS = Object.values(TRENDING_FAMILIES).flat();
 
 // Model organization filter options
 export const MODEL_ORGS = [
+  { key: 'openbmb', label: 'OpenBMB' },
   { key: 'Qwen', label: 'Qwen' },
   { key: 'meta-llama', label: 'Llama' },
   { key: 'google', label: 'Google' },


### PR DESCRIPTION
## Summary
- add the official MiniCPM5 2B GGUF repository at the top of the mobile catalog
- mark MiniCPM5 as trending and add the OpenBMB organization filter
- show the verified tick for official compact model cards instead of the Official label

## Checks
- ESLint passed for changed files
- TypeScript passed in the active mobile checkout
- constants tests passed
- component and trending tests could not resolve the shared workspace package from the isolated temporary worktree path