### PR TITLE
Chat release: preserve turns and isolate streaming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
   pull_request:
     branches:
       - main
+      - 'release/**'
 
 # ONE job, not four.
 #

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -83,6 +83,11 @@ ${file}"
 __tests__/unit/services/generationService.test.ts
 __tests__/integration/generation/errorKeepsPartial.rendered.redflow.test.tsx"
         ;;
+      src/services/llmHelpers.ts)
+        MAPPED_TESTS="${MAPPED_TESTS}
+__tests__/unit/services/llmHelpers.test.ts
+__tests__/unit/services/llmHelpers.branches.test.ts"
+        ;;
       *)
         RELATED_JS="${RELATED_JS}
 ${file}"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -66,7 +66,41 @@ if [ -n "$PUSHED_JS" ]; then
   echo "▶ JS/TS tests (related to changed files)..."
   # Keep related rendered journeys serial because they share native-boundary state.
   # Do not force the process to exit: leaked asynchronous work is a test failure to fix.
-  echo "$PUSHED_JS" | tr '\n' '\0' | xargs -0 npx jest --findRelatedTests --passWithNoTests --runInBand --bail=1
+  DIRECT_TESTS=""
+  MAPPED_TESTS=""
+  RELATED_JS=""
+  while IFS= read -r file; do
+    case "$file" in
+      __tests__/*|*/__tests__/*|*.test.ts|*.test.tsx|*.test.js|*.test.jsx)
+        DIRECT_TESTS="${DIRECT_TESTS}
+${file}"
+        ;;
+      src/services/generationRemoteHelpers.ts)
+        # This helper is imported through the central generation barrel. Jest's
+        # unrestricted reverse graph reaches most screens through the navigator,
+        # although those screens cannot execute this remote-generation contract.
+        MAPPED_TESTS="${MAPPED_TESTS}
+__tests__/unit/services/generationService.test.ts
+__tests__/integration/generation/errorKeepsPartial.rendered.redflow.test.tsx"
+        ;;
+      *)
+        RELATED_JS="${RELATED_JS}
+${file}"
+        ;;
+    esac
+  done <<EOF
+$PUSHED_JS
+EOF
+  SELECTED_TESTS=$(printf '%s\n%s\n' "$DIRECT_TESTS" "$MAPPED_TESTS" | sed '/^$/d' | sort -u)
+  if [ -n "$SELECTED_TESTS" ]; then
+    printf '%s\n' "$SELECTED_TESTS" | tr '\n' '\0' | \
+      xargs -0 npx jest --passWithNoTests --runInBand --bail=1
+  fi
+  RELATED_JS=$(printf '%s\n' "$RELATED_JS" | sed '/^$/d' | sort -u)
+  if [ -n "$RELATED_JS" ]; then
+    printf '%s\n' "$RELATED_JS" | tr '\n' '\0' | \
+      xargs -0 npx jest --findRelatedTests --passWithNoTests --runInBand --bail=1
+  fi
 
   echo "▶ Architecture gate (dependency-cruiser)..."
   npm run depcruise

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,6 +2,18 @@
 
 ZERO_OID="0000000000000000000000000000000000000000"
 
+new_branch_base() {
+  local_oid=$1
+  for candidate in "${OFFGRID_PUSH_BASE:-}" origin/release/computer_use origin/main; do
+    [ -z "$candidate" ] && continue
+    if git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+      git merge-base "$local_oid" "$candidate"
+      return
+    fi
+  done
+  git rev-list --max-parents=0 "$local_oid" | tail -1
+}
+
 collect_changed_files() {
   changed_files=""
 
@@ -15,14 +27,11 @@ collect_changed_files() {
     [ "$local_oid" = "$ZERO_OID" ] && continue
 
     if [ "$remote_oid" = "$ZERO_OID" ]; then
-      # A new branch has no remote tip. Inspect only commits that are not already
-      # reachable from origin instead of assuming the branch started from main.
-      commits=$(git rev-list "$local_oid" --not --remotes=origin 2>/dev/null || true)
-      if [ -n "$commits" ]; then
-        changed=$(git diff-tree --no-commit-id --name-only -r --diff-filter=ACMR $commits)
-      else
-        changed=""
-      fi
+      # A new branch has no remote tip. Diff its complete range from the release
+      # base. Passing several commits to diff-tree can silently compare trees and
+      # omit earlier commits in the push.
+      base=$(new_branch_base "$local_oid")
+      changed=$(git diff --name-only --diff-filter=ACMR "$base..$local_oid")
     else
       range="$remote_oid..$local_oid"
       changed=$(git diff --name-only --diff-filter=ACMR "$range")

--- a/__tests__/pro/chatStreamCadence.test.ts
+++ b/__tests__/pro/chatStreamCadence.test.ts
@@ -1,0 +1,29 @@
+import {
+  ChatStreamCadence,
+  chatStreamCadenceKey,
+} from '../../pro/sync/chatStreamCadence';
+
+test('token bursts are sampled while lifecycle changes are immediate', async () => {
+  const delivered: string[] = [];
+  const cadence = new ChatStreamCadence(state => {
+    if (state && !('completion' in state)) delivered.push(state.content);
+  });
+  const first = { conversationId: 'chat-1', content: 'a' };
+  const second = { conversationId: 'chat-1', content: 'ab' };
+
+  cadence.submit(first, chatStreamCadenceKey(first, 0));
+  cadence.submit(second, chatStreamCadenceKey(second, 0));
+  expect(delivered).toEqual(['a']);
+
+  await new Promise(resolve => setTimeout(resolve, 70));
+  expect(delivered).toEqual(['a', 'ab']);
+
+  const changed = {
+    conversationId: 'chat-1',
+    content: 'ab',
+    phase: 'using_tools' as const,
+  };
+  cadence.submit(changed, chatStreamCadenceKey(changed, 0));
+  expect(delivered).toEqual(['a', 'ab', 'ab']);
+  cadence.stop();
+});

--- a/__tests__/pro/chatStreamCadence.test.ts
+++ b/__tests__/pro/chatStreamCadence.test.ts
@@ -21,7 +21,7 @@ test('token bursts are sampled while lifecycle changes are immediate', async () 
   const changed = {
     conversationId: 'chat-1',
     content: 'ab',
-    phase: 'using_tools' as const,
+    phase: 'thinking' as const,
   };
   cadence.submit(changed, chatStreamCadenceKey(changed, 0));
   expect(delivered).toEqual(['a', 'ab', 'ab']);

--- a/__tests__/rntl/screens/ProjectChatsScreen.test.tsx
+++ b/__tests__/rntl/screens/ProjectChatsScreen.test.tsx
@@ -33,19 +33,26 @@ const mockSetActiveConversation = jest.fn();
 const mockCreateConversation = jest.fn(() => 'new-conv-id');
 
 jest.mock('../../../src/stores', () => ({
-  useProjectStore: jest.fn(() => ({
-    getProject: () => mockProject,
-  })),
-  useChatStore: jest.fn(() => ({
-    conversations: mockConversations,
-    deleteConversation: mockDeleteConversation,
-    setActiveConversation: mockSetActiveConversation,
-    createConversation: mockCreateConversation,
-  })),
-  useAppStore: jest.fn(() => ({
-    downloadedModels: mockDownloadedModels,
-    activeModelId: mockActiveModelId,
-  })),
+  useProjectStore: jest.fn((selector?: any) => {
+    const state = { getProject: () => mockProject };
+    return selector ? selector(state) : state;
+  }),
+  useChatStore: jest.fn((selector?: any) => {
+    const state = {
+      conversations: mockConversations,
+      deleteConversation: mockDeleteConversation,
+      setActiveConversation: mockSetActiveConversation,
+      createConversation: mockCreateConversation,
+    };
+    return selector ? selector(state) : state;
+  }),
+  useAppStore: jest.fn((selector?: any) => {
+    const state = {
+      downloadedModels: mockDownloadedModels,
+      activeModelId: mockActiveModelId,
+    };
+    return selector ? selector(state) : state;
+  }),
 }));
 
 jest.mock('../../../src/components/Button', () => ({

--- a/__tests__/rntl/screens/ProjectDetailScreen.test.tsx
+++ b/__tests__/rntl/screens/ProjectDetailScreen.test.tsx
@@ -55,16 +55,22 @@ let mockDownloadedModels: any[] = [{ id: 'model1', name: 'Test Model' }];
 let mockActiveModelId: string | null = 'model1';
 
 jest.mock('../../../src/stores', () => ({
-  useProjectStore: jest.fn(() => ({
-    getProject: jest.fn(() => mockProject),
-    deleteProject: mockDeleteProject,
-  })),
-  useChatStore: jest.fn(() => ({
-    conversations: mockConversations,
-    deleteConversation: mockDeleteConversation,
-    setActiveConversation: mockSetActiveConversation,
-    createConversation: mockCreateConversation,
-  })),
+  useProjectStore: jest.fn((selector?: any) => {
+    const state = {
+      getProject: jest.fn(() => mockProject),
+      deleteProject: mockDeleteProject,
+    };
+    return selector ? selector(state) : state;
+  }),
+  useChatStore: jest.fn((selector?: any) => {
+    const state = {
+      conversations: mockConversations,
+      deleteConversation: mockDeleteConversation,
+      setActiveConversation: mockSetActiveConversation,
+      createConversation: mockCreateConversation,
+    };
+    return selector ? selector(state) : state;
+  }),
   useAppStore: jest.fn((selector?: any) => {
     const state = {
       downloadedModels: mockDownloadedModels,

--- a/__tests__/unit/components/ChatMessage/utils.test.ts
+++ b/__tests__/unit/components/ChatMessage/utils.test.ts
@@ -4,7 +4,25 @@
  * Unit tests for parseThinkingContent, formatTime, formatDuration
  */
 
-import { parseThinkingContent, formatTime, formatDuration } from '../../../../src/components/ChatMessage/utils';
+import { buildMessageData, parseThinkingContent, formatTime, formatDuration } from '../../../../src/components/ChatMessage/utils';
+
+describe('buildMessageData', () => {
+  it('reuses a committed message projection until its content changes', () => {
+    const message = {
+      id: 'assistant-1',
+      role: 'assistant' as const,
+      content: '<think>Check</think>Answer',
+      timestamp: 1,
+    };
+    const first = buildMessageData(message);
+    expect(buildMessageData(message)).toBe(first);
+
+    message.content = '<think>Check again</think>New answer';
+    const changed = buildMessageData(message);
+    expect(changed).not.toBe(first);
+    expect(changed.displayContent).toBe('New answer');
+  });
+});
 
 describe('parseThinkingContent', () => {
   // ============================================================================

--- a/__tests__/unit/hooks/useChatGenerationActions.test.ts
+++ b/__tests__/unit/hooks/useChatGenerationActions.test.ts
@@ -1350,7 +1350,11 @@ describe('generateWithCompactionRetry — context full error path', () => {
     (llmService.stopGeneration as jest.Mock).mockResolvedValue(undefined);
 
     const conv = { id: 'conv-1', messages: [{ id: 'm1', role: 'user', content: 'hi', timestamp: 0 }] };
-    mockChatStoreGetState.mockReturnValue({ conversations: [conv], updateCompactionState: jest.fn() });
+    mockChatStoreGetState.mockReturnValue({
+      conversations: [conv],
+      updateCompactionState: jest.fn(),
+      addMessage: jest.fn(),
+    });
     const deps = makeGenerationDeps();
     await startGenerationFn(deps, { setDebugInfo: jest.fn(), targetConversationId: 'conv-1', messageText: 'hi' });
     // Second call should be with the compacted messages
@@ -1371,7 +1375,11 @@ describe('generateWithCompactionRetry — context full error path', () => {
       { id: 'm1', role: 'user', content: 'old', timestamp: 0 },
       { id: 'm2', role: 'assistant', content: 'reply', timestamp: 0 },
     ]};
-    mockChatStoreGetState.mockReturnValue({ conversations: [conv], updateCompactionState: jest.fn() });
+    mockChatStoreGetState.mockReturnValue({
+      conversations: [conv],
+      updateCompactionState: jest.fn(),
+      addMessage: jest.fn(),
+    });
     const deps = makeGenerationDeps();
     await startGenerationFn(deps, { setDebugInfo: jest.fn(), targetConversationId: 'conv-1', messageText: 'hi' });
     expect(mockClearKVCache).toHaveBeenCalledWith(true);

--- a/__tests__/unit/hooks/useChatGenerationActions.test.ts
+++ b/__tests__/unit/hooks/useChatGenerationActions.test.ts
@@ -144,7 +144,13 @@ const mockGetDocsByProject = ragService.getDocumentsByProject as jest.Mock;
 const mockFormatForPrompt = retrievalService.formatForPrompt as jest.Mock;
 
 
-const mockChatStoreGetState = jest.fn(() => ({ conversations: [] as any[], updateCompactionState: jest.fn() }));
+const mockChatStoreGetState = jest.fn(
+  (): {
+    conversations: any[];
+    updateCompactionState: jest.Mock;
+    addMessage?: jest.Mock;
+  } => ({ conversations: [], updateCompactionState: jest.fn() }),
+);
 jest.mock('../../../src/stores/chatStore', () => ({
   useChatStore: { getState: () => mockChatStoreGetState() },
 }));

--- a/__tests__/unit/hooks/useHomeScreen.test.ts
+++ b/__tests__/unit/hooks/useHomeScreen.test.ts
@@ -105,12 +105,15 @@ jest.mock('../../../src/stores', () => {
   useRemoteServerStore.getState = () => remoteState;
   return {
     useAppStore,
-    useChatStore: jest.fn(() => ({
+    useChatStore: jest.fn((selector?: any) => {
+      const state = {
       conversations: [],
       createConversation: mockCreateConversation,
       setActiveConversation: mockSetActiveConversation,
       deleteConversation: mockDeleteConversation,
-    })),
+      };
+      return selector ? selector(state) : state;
+    }),
     useRemoteServerStore,
   };
 });
@@ -142,11 +145,14 @@ describe('useHomeScreen', () => {
       };
       return selector ? selector(state) : state;
     });
-    (useChatStore as unknown as jest.Mock).mockReturnValue({
-      conversations: [],
-      createConversation: mockCreateConversation,
-      setActiveConversation: mockSetActiveConversation,
-      deleteConversation: mockDeleteConversation,
+    (useChatStore as unknown as jest.Mock).mockImplementation((selector?: any) => {
+      const state = {
+        conversations: [],
+        createConversation: mockCreateConversation,
+        setActiveConversation: mockSetActiveConversation,
+        deleteConversation: mockDeleteConversation,
+      };
+      return selector ? selector(state) : state;
     });
     (useAppStore as unknown as jest.Mock).mockImplementation((sel?: any) => {
       const st = {

--- a/__tests__/unit/services/providers/openAICompatibleProvider.test.ts
+++ b/__tests__/unit/services/providers/openAICompatibleProvider.test.ts
@@ -171,6 +171,45 @@ describe('OpenAICompatibleProvider', () => {
   });
 
   describe('generate', () => {
+    it('sends the provider-native reasoning budget to OpenRouter', async () => {
+      const openRouter = new OpenAICompatibleProvider('openrouter', {
+        endpoint: 'https://openrouter.ai/api',
+        modelId: 'reasoning-model',
+      });
+      const request = httpClient.createStreamingRequest as jest.Mock;
+      request.mockImplementation((_url, _req, onEvent) => {
+        onEvent({ data: '[DONE]' });
+        return Promise.resolve();
+      });
+
+      await openRouter.generate(
+        [{ id: '1', role: 'user', content: 'Think', timestamp: 0 }],
+        { enableThinking: true, reasoningBudget: 2048 },
+        { onToken: jest.fn(), onComplete: jest.fn(), onError: jest.fn() },
+      );
+
+      expect(request.mock.calls[0][1].body.reasoning).toEqual({ max_tokens: 2048 });
+    });
+
+    it('sends enable_thinking only when a compatible server advertises it', async () => {
+      provider.updateCapabilities({ supportsThinking: true, acceptsThinkingKwarg: true });
+      const request = httpClient.createStreamingRequest as jest.Mock;
+      request.mockImplementation((_url, _req, onEvent) => {
+        onEvent({ data: '[DONE]' });
+        return Promise.resolve();
+      });
+
+      await provider.generate(
+        [{ id: '1', role: 'user', content: 'Answer directly', timestamp: 0 }],
+        { enableThinking: false },
+        { onToken: jest.fn(), onComplete: jest.fn(), onError: jest.fn() },
+      );
+
+      expect(request.mock.calls[0][1].body.chat_template_kwargs).toEqual({
+        enable_thinking: false,
+      });
+    });
+
     it('should call onError when no model is loaded', async () => {
       // Create a provider without initial model
       const emptyProvider = new OpenAICompatibleProvider('empty', {

--- a/__tests__/unit/services/providers/openAICompatibleStream.test.ts
+++ b/__tests__/unit/services/providers/openAICompatibleStream.test.ts
@@ -251,6 +251,19 @@ describe('generateOllamaChatImpl', () => {
     jest.clearAllMocks();
   });
 
+  it('sends the reasoning toggle through Ollama native chat', async () => {
+    const req = makeOllamaReq({ options: { enableThinking: false } });
+    let body: any;
+    mockedNDJSON.mockImplementation(async (_url: string, request: any, handler: (line: any) => void) => {
+      body = request.body;
+      handler({ done: true });
+    });
+
+    await generateOllamaChatImpl([], req);
+
+    expect(body.think).toBe(false);
+  });
+
   it('calls onComplete with content when done=true line received', async () => {
     const req = makeOllamaReq();
     mockedNDJSON.mockImplementation(async (_url: string, _opts: any, handler: (line: any) => void) => {

--- a/__tests__/unit/utils/hydrationGatedStorage.test.ts
+++ b/__tests__/unit/utils/hydrationGatedStorage.test.ts
@@ -1,110 +1,48 @@
 import type { StateStorage } from 'zustand/middleware';
-import { persist } from 'zustand/middleware';
-import { createStore } from 'zustand/vanilla';
 import { createHydrationGatedStorage } from '../../../src/utils/hydrationGatedStorage';
 
-function memoryStorage(initial: Record<string, string> = {}): StateStorage & {
-  values: Map<string, string>;
-} {
-  const values = new Map(Object.entries(initial));
-  return {
-    values,
-    getItem: async name => values.get(name) ?? null,
-    setItem: async (name, value) => {
-      values.set(name, value);
+type StoredState = {
+  conversations: readonly { id: string }[];
+  activeConversationId: string | null;
+  streamingMessage?: string;
+};
+
+test('ephemeral stream changes do not rewrite durable chat storage', async () => {
+  let raw = JSON.stringify({
+    state: { conversations: [{ id: 'chat-1' }], activeConversationId: 'chat-1' },
+    version: 1,
+  });
+  let writes = 0;
+  const base: StateStorage = {
+    getItem: async () => raw,
+    setItem: async (_name, value) => {
+      writes += 1;
+      raw = value;
     },
-    removeItem: async name => {
-      values.delete(name);
-    },
+    removeItem: async () => undefined,
   };
-}
+  const gated = createHydrationGatedStorage<StoredState>(
+    base,
+    (previous, next) =>
+      previous.conversations === next.conversations &&
+      previous.activeConversationId === next.activeConversationId,
+  );
+  const loaded = await gated.storage.getItem('chat');
+  gated.markHydrated();
+  const durable = loaded!.state;
 
-describe('hydration-gated storage', () => {
-  it('preserves saved state from writes and removal before hydration', async () => {
-    const saved = JSON.stringify({ state: { selected: 'saved' }, version: 0 });
-    const base = memoryStorage({ settings: saved });
-    const gated = createHydrationGatedStorage<{ selected: string }>(base);
-
-    await gated.storage.setItem('settings', {
-      state: { selected: 'default' },
-      version: 0,
-    });
-    await gated.storage.removeItem('settings');
-
-    expect(await gated.storage.getItem('settings')).toEqual({
-      state: { selected: 'saved' },
-      version: 0,
-    });
+  await gated.storage.setItem('chat', {
+    state: { ...durable, streamingMessage: 'one token' },
+    version: 1,
   });
+  expect(writes).toBe(0);
 
-  it('persists changes after hydration completes', async () => {
-    const base = memoryStorage();
-    const gated = createHydrationGatedStorage<{ selected: string }>(base);
-
-    gated.markHydrated();
-    expect(gated.isHydrated()).toBe(true);
-    await gated.storage.setItem('settings', {
-      state: { selected: 'next' },
-      version: 0,
-    });
-    expect(await gated.storage.getItem('settings')).toEqual({
-      state: { selected: 'next' },
-      version: 0,
-    });
-    await gated.storage.removeItem('settings');
-    expect(await gated.storage.getItem('settings')).toBeNull();
+  await gated.storage.setItem('chat', {
+    state: {
+      ...durable,
+      conversations: [...durable.conversations, { id: 'chat-2' }],
+    },
+    version: 1,
   });
-
-  it('keeps saved state through a delayed hydration and the next store restart', async () => {
-    let releaseRead = () => {};
-    const readBlocked = new Promise<void>(resolve => {
-      releaseRead = resolve;
-    });
-    const base = memoryStorage({
-      settings: JSON.stringify({ state: { selected: 'saved' }, version: 0 }),
-    });
-    const delayedBase: StateStorage = {
-      ...base,
-      getItem: async name => {
-        await readBlocked;
-        return base.getItem(name);
-      },
-    };
-
-    const first = createPersistedSelection(delayedBase);
-    first.store.setState({ selected: 'boot-default' });
-    first.store.persist.clearStorage();
-    releaseRead();
-    await waitForHydration(first.store);
-
-    expect(first.store.getState().selected).toBe('saved');
-    first.store.setState({ selected: 'after-hydration' });
-
-    const restarted = createPersistedSelection(base);
-    await waitForHydration(restarted.store);
-    expect(restarted.store.getState().selected).toBe('after-hydration');
-  });
+  expect(writes).toBe(1);
 });
-
-type Selection = { selected: string };
-
-function createPersistedSelection(base: StateStorage) {
-  const gate = createHydrationGatedStorage<Selection>(base);
-  const store = createStore<Selection>()(
-    persist(() => ({ selected: 'default' }), {
-      name: 'settings',
-      storage: gate.storage,
-      onRehydrateStorage: () => () => gate.markHydrated(),
-    }),
-  );
-  return { gate, store };
-}
-
-function waitForHydration(
-  store: ReturnType<typeof createPersistedSelection>['store'],
-): Promise<void> {
-  if (store.persist.hasHydrated()) return Promise.resolve();
-  return new Promise(resolve =>
-    store.persist.onFinishHydration(() => resolve()),
-  );
-}

--- a/rules.md
+++ b/rules.md
@@ -276,19 +276,19 @@ When the user says "push" (or any equivalent like "ship it", "send it", "push th
 
 ### Before pushing
 0. Write tests for any new or changed logic if they don't already exist.
-1. Run `npm run lint && npx tsc --noEmit && npm test` - fix any failures before continuing.
-2. Commit all staged changes with a descriptive message.
-3. Ensure you are NOT on `main`. If you are, create an appropriately named branch first: `git checkout -b feat/...` or `fix/...` or `chore/...` etc.
+1. Commit all staged changes with a descriptive message.
+2. Ensure you are NOT on `main`. If you are, create an appropriately named branch first: `git checkout -b feat/...` or `fix/...` or `chore/...` etc.
 
 ### Pushing & PR
-4. Push the branch: `git push -u origin <branch>`
+3. Push the branch normally: `git push -u origin <branch>`. The pre-push hook is the required local quality gate and owns lint, typecheck, and the applicable test suite. Never bypass it with `--no-verify`.
+4. If the pre-push hook fails, fix the reported failure, commit the fix, and push again. Run a full lint, typecheck, or test command separately only when it is needed to diagnose that hook failure.
 5. If no PR exists for this branch, create one with `gh pr create`. **Do NOT include "Generated with Codex" or any AI attribution in PR descriptions.**
 6. If a PR already exists, update its description to reflect **all commits in the PR** (not just the latest push). Read the full commit history with `git log main..HEAD` and write a coherent description that summarises the entire change set - what it does, why, and how.
 
 ### Review loop
 7. Wait for Gemini to review the PR (poll with `gh pr checks` and `gh api repos/{owner}/{repo}/pulls/{number}/reviews` until a review appears).
 8. Pull down review comments: `gh api repos/{owner}/{repo}/pulls/{number}/comments` and `gh api repos/{owner}/{repo}/pulls/{number}/reviews`.
-9. Address every review comment - fix the code, re-run quality gates (lint, tsc, test).
+9. Address every review comment - fix the code, commit it, and let the next normal push run the pre-push quality gate.
 10. Reply to **each** review comment individually using `gh api` (`/pulls/comments/{id}/replies`). Every comment gets its own reply - do not post a single summary comment.
 11. Push fixes, update the PR description again to stay coherent across all commits.
 12. Report what was changed in response to the review.
@@ -307,7 +307,7 @@ The repo has three automated reviewers on every PR. After pushing, loop until al
 1. Push code → wait for all three reviewers to report
 2. Pull down Gemini comments, Codecov report, and SonarCloud findings
 3. Fix issues: code changes for Gemini/SonarCloud, add tests for Codecov
-4. Re-run local quality gates (`npm run lint && npm test && npx tsc --noEmit`)
+4. Commit the fixes and push normally. The pre-push hook runs the local quality gates.
 5. Push fixes, comment `/gemini review` on the PR to re-trigger Gemini
 6. Repeat until all three reviewers pass with no blocking issues
 

--- a/src/components/AppSheet.tsx
+++ b/src/components/AppSheet.tsx
@@ -215,6 +215,7 @@ export const AppSheet: React.FC<AppSheetProps> = ({
 
   useEffect(() => {
     if (visible) {
+      if (modalVisible) return;
       pendingAnimateIn.current = true;
       // Dismiss keyboard first, then open — prevents animation conflict
       const keyboardVisible = Keyboard.isVisible?.() ?? false;

--- a/src/components/ChatInput/Popovers.tsx
+++ b/src/components/ChatInput/Popovers.tsx
@@ -117,7 +117,9 @@ export const QuickSettingsPopover: React.FC<QuickSettingsPopoverProps> = ({
   mcpToolCount = 0, onMcpPress,
 }) => {
   const { colors } = useTheme();
-  const { settings, updateSettings, toolCountHintDismissed } = useAppStore();
+  const thinkingEnabled = useAppStore(state => state.settings.thinkingEnabled);
+  const updateSettings = useAppStore(state => state.updateSettings);
+  const toolCountHintDismissed = useAppStore(state => state.toolCountHintDismissed);
 
   if (!visible) return null;
 
@@ -177,16 +179,16 @@ export const QuickSettingsPopover: React.FC<QuickSettingsPopoverProps> = ({
                   style={popoverStyles.row}
                   onPress={() => {
                     triggerHaptic('impactLight');
-                    updateSettings({ thinkingEnabled: !settings.thinkingEnabled });
+                    updateSettings({ thinkingEnabled: !thinkingEnabled });
                   }}
                 >
-                  <Icon name="zap" size={16} color={settings.thinkingEnabled ? colors.primary : colors.textMuted} />
+                  <Icon name="zap" size={16} color={thinkingEnabled ? colors.primary : colors.textMuted} />
                   <Text style={[popoverStyles.rowLabel, { color: colors.text }]}>Thinking</Text>
                   <View style={[popoverStyles.badge, {
-                    backgroundColor: settings.thinkingEnabled ? colors.primary : colors.textMuted,
+                    backgroundColor: thinkingEnabled ? colors.primary : colors.textMuted,
                   }]}>
                     <Text style={[popoverStyles.badgeText, { color: colors.background }]}>
-                      {settings.thinkingEnabled ? 'ON' : 'OFF'}
+                      {thinkingEnabled ? 'ON' : 'OFF'}
                     </Text>
                   </View>
                 </TouchableOpacity>

--- a/src/components/ChatInput/Voice.ts
+++ b/src/components/ChatInput/Voice.ts
@@ -83,7 +83,8 @@ export function useVoiceInput({ conversationId, interfaceMode, onTranscript, onA
   onAudioAttachmentRef.current = onAudioAttachment;
   const onAutoSendRef = useRef(onAutoSend);
   onAutoSendRef.current = onAutoSend;
-  const { downloadedModelId, transcriptionLanguage } = useWhisperStore();
+  const downloadedModelId = useWhisperStore(state => state.downloadedModelId);
+  const transcriptionLanguage = useWhisperStore(state => state.transcriptionLanguage);
   const remoteTranscriptionAvailable = useRemoteTranscriptionAvailable();
   const [isDirectRecording, setIsDirectRecording] = useState(false);
   const [isAudioModeRecording, setIsAudioModeRecording] = useState(false);

--- a/src/components/ChatInput/index.tsx
+++ b/src/components/ChatInput/index.tsx
@@ -216,8 +216,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     isStartingRecording ||
     isTranscribing;
 
-  const { settings: appSettings, updateSettings: updateAppSettings } = useAppStore();
-  const thinkingEnabled = appSettings.thinkingEnabled;
+  const thinkingEnabled = useAppStore(state => state.settings.thinkingEnabled);
+  const updateAppSettings = useAppStore(state => state.updateSettings);
 
   const handleThinkingToggle = () => {
     triggerHaptic('impactLight');

--- a/src/components/ChatMessage/components/ActionMenuSheet.tsx
+++ b/src/components/ChatMessage/components/ActionMenuSheet.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, TextInput, ScrollView } from 'react-native';
 import Icon from 'react-native-vector-icons/Feather';
 import { useTheme } from '../../../theme';
@@ -157,8 +157,7 @@ interface EditSheetProps {
   visible: boolean;
   onClose: () => void;
   defaultValue: string;
-  onChangeText: (text: string) => void;
-  onSave: () => void;
+  onSave: (text: string) => void;
   onCancel: () => void;
   styles: any;
   colors: any;
@@ -168,12 +167,17 @@ export function EditSheet({
   visible,
   onClose,
   defaultValue,
-  onChangeText,
   onSave,
   onCancel,
   styles,
   colors,
 }: EditSheetProps) {
+  const [draft, setDraft] = useState(defaultValue);
+
+  useEffect(() => {
+    if (visible) setDraft(defaultValue);
+  }, [defaultValue, visible]);
+
   return (
     <AppSheet
       visible={visible}
@@ -184,8 +188,8 @@ export function EditSheet({
       <View style={styles.editSheetContent}>
         <TextInput
           style={styles.editInput}
-          defaultValue={defaultValue}
-          onChangeText={onChangeText}
+          value={draft}
+          onChangeText={setDraft}
           multiline
           autoFocus
           placeholder="Enter message..."
@@ -203,7 +207,7 @@ export function EditSheet({
           <AnimatedPressable
             hapticType="impactMedium"
             style={[styles.editButton, styles.editButtonSave]}
-            onPress={onSave}
+            onPress={() => onSave(draft)}
           >
             <Text style={[styles.editButtonText, styles.editButtonTextSave]}>SAVE & RESEND</Text>
           </AnimatedPressable>

--- a/src/components/ChatMessage/components/MessageOverlays.tsx
+++ b/src/components/ChatMessage/components/MessageOverlays.tsx
@@ -24,14 +24,13 @@ interface MessageOverlaysProps {
   alertState: AlertState;
   onCloseActionMenu: () => void;
   onCloseSelectText: () => void;
-  onChangeEditText: (text: string) => void;
   onCopy: () => void;
   onEdit: () => void;
   onRetry: () => void;
   onGenerateImage: () => void;
   onSpeak: () => void;
   onSelectText: () => void;
-  onSaveEdit: () => void;
+  onSaveEdit: (text: string) => void;
   onCancelEdit: () => void;
   onCloseAlert: () => void;
 }
@@ -39,7 +38,7 @@ interface MessageOverlaysProps {
 export const MessageOverlays: React.FC<MessageOverlaysProps> = ({
   message, styles, colors, showActionMenu, showSelectText, isEditing, isUser,
   canEdit, canRetry, canGenerateImage, canSpeak, showSelectTextAction, displayContent,
-  alertState, onCloseActionMenu, onCloseSelectText, onChangeEditText, onCopy, onEdit,
+  alertState, onCloseActionMenu, onCloseSelectText, onCopy, onEdit,
   onRetry, onGenerateImage, onSpeak, onSelectText, onSaveEdit, onCancelEdit, onCloseAlert,
 }) => (
   <>
@@ -69,7 +68,6 @@ export const MessageOverlays: React.FC<MessageOverlaysProps> = ({
       visible={isEditing}
       onClose={onCancelEdit}
       defaultValue={message.content}
-      onChangeText={onChangeEditText}
       onSave={onSaveEdit}
       onCancel={onCancelEdit}
       styles={styles}

--- a/src/components/ChatMessage/components/ToolMessages.tsx
+++ b/src/components/ChatMessage/components/ToolMessages.tsx
@@ -284,39 +284,74 @@ export const SyncedToolArtifacts: React.FC<{
  * while every finished result sat 16px from its neighbour - the same tool, two rhythms, in one
  * transcript.
  */
+type ToolCallRow = {
+  key: string;
+  stableKey: string;
+  name: string;
+  icon: string;
+  label: string;
+};
+
+function toolArgumentsLabel(args: string | undefined): string {
+  let preview: string | undefined;
+  try {
+    preview = Object.values(JSON.parse(args as string)).join(', ');
+  } catch {
+    preview = args;
+  }
+  return preview ? `: ${preview}` : '';
+}
+
+const toolCallRowsByMessage = new WeakMap<
+  Message,
+  { calls: NonNullable<Message['toolCalls']>; rows: readonly ToolCallRow[] }
+>();
+const NO_TOOL_CALL_ROWS: readonly ToolCallRow[] = [];
+
+function toolCallRows(message: Message): readonly ToolCallRow[] {
+  const calls = message.toolCalls;
+  if (!calls?.length) return NO_TOOL_CALL_ROWS;
+  const cached = toolCallRowsByMessage.get(message);
+  if (cached?.calls === calls) return cached.rows;
+  const messageKey = message.uuid ?? message.id;
+  const rows = calls.map((call, index) => {
+    const callKey = `${call.id || index}`;
+    return {
+      key: callKey,
+      stableKey: `${messageKey}:call:${callKey}`,
+      name: call.name,
+      icon: getToolIcon(call.name),
+      label: `Using ${call.name}${toolArgumentsLabel(call.arguments)}`,
+    };
+  });
+  toolCallRowsByMessage.set(message, { calls, rows });
+  return rows;
+}
+
 export const ToolCallMessage: React.FC<{
   message: Message;
   styles: any;
   colors: any;
 }> = ({ message, styles, colors }) => (
   <View testID="tool-call-message">
-    {message.toolCalls?.map((tc, i) => {
-      let argsPreview = '';
-      try {
-        argsPreview = Object.values(JSON.parse(tc.arguments)).join(', ');
-      } catch {
-        argsPreview = tc.arguments;
-      }
-      const argsLabel = argsPreview ? `: ${argsPreview}` : '';
-      return (
+    {toolCallRows(message).map(row => (
         <ToolResultBubble
-          key={`${tc.id || i}`}
-          stableKey={`${message.uuid ?? message.id}:call:${tc.id || i}`}
-          toolIcon={getToolIcon(tc.name)}
-          toolLabel={`Using ${tc.name}${argsLabel}`}
-          toolName={tc.name}
+          key={row.key}
+          stableKey={row.stableKey}
+          toolIcon={row.icon}
+          toolLabel={row.label}
+          toolName={row.name}
           durationLabel=""
           content=""
           hasDetails={false}
           active
           paired
           rowTestID="tool-call-row"
-          labelTestID={`tool-call-label-${tc.name || 'unknown'}`}
+          labelTestID={`tool-call-label-${row.name || 'unknown'}`}
           styles={styles}
           colors={colors}
         />
-      );
-    })}
+      ))}
   </View>
 );
 

--- a/src/components/ChatMessage/index.tsx
+++ b/src/components/ChatMessage/index.tsx
@@ -263,7 +263,6 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
   const [showActionMenu, setShowActionMenu] = useState(false);
   const [showSelectText, setShowSelectText] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
-  const [editedContent, setEditedContent] = useState(message.content);
   const [showThinking, setShowThinking] = useState(!!isStreaming);
   const [showSupportingContext, setShowSupportingContext] = useState(false);
   const [alertState, setAlertState] = useState<AlertState>(initialAlertState);
@@ -302,7 +301,6 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
   };
 
   const handleEdit = () => {
-    setEditedContent(message.content);
     setShowActionMenu(false);
     setTimeout(() => setIsEditing(true), 350);
   };
@@ -313,14 +311,13 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
     setTimeout(() => setShowSelectText(true), 350);
   };
 
-  const handleSaveEdit = () => {
-    const trimmed = editedContent.trim();
+  const handleSaveEdit = (content: string) => {
+    const trimmed = content.trim();
     if (trimmed !== message.content) onEdit?.(message, trimmed);
     setIsEditing(false);
   };
 
   const handleCancelEdit = () => {
-    setEditedContent(message.content);
     setIsEditing(false);
   };
 
@@ -446,7 +443,6 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
         alertState={alertState}
         onCloseActionMenu={() => setShowActionMenu(false)}
         onCloseSelectText={() => setShowSelectText(false)}
-        onChangeEditText={setEditedContent}
         onCopy={handleCopy}
         onEdit={handleEdit}
         onRetry={handleRetry}

--- a/src/components/ChatMessage/utils.ts
+++ b/src/components/ChatMessage/utils.ts
@@ -22,7 +22,35 @@ export function formatDuration(ms: number): string {
   return `${minutes}m ${remainingSeconds}s`;
 }
 
-export function buildMessageData(message: Message): { displayContent: string; parsedContent: ParsedContent } {
+export type MessageData = { displayContent: string; parsedContent: ParsedContent };
+
+const parsedMessages = new WeakMap<
+  Message,
+  {
+    content: string;
+    reasoningContent?: string;
+    data: MessageData;
+  }
+>();
+
+export function buildMessageData(message: Message): MessageData {
+  const cached = parsedMessages.get(message);
+  if (
+    cached?.content === message.content &&
+    cached.reasoningContent === message.reasoningContent
+  ) {
+    return cached.data;
+  }
+  const data = parseMessageData(message);
+  parsedMessages.set(message, {
+    content: message.content,
+    reasoningContent: message.reasoningContent,
+    data,
+  });
+  return data;
+}
+
+function parseMessageData(message: Message): MessageData {
   // Non-assistant messages carry no model markup — pass content straight through.
   if (message.role !== 'assistant') {
     return { displayContent: message.content, parsedContent: { thinking: null, response: message.content, isThinkingComplete: true } };

--- a/src/screens/ChatScreen/ChatMessageArea.tsx
+++ b/src/screens/ChatScreen/ChatMessageArea.tsx
@@ -1,11 +1,5 @@
 import React, { useState, useMemo, useEffect, useRef } from 'react';
-import {
-  View,
-  FlatList,
-  Text,
-  Keyboard,
-  Platform,
-} from 'react-native';
+import { View, FlatList, Text, Platform } from 'react-native';
 import { useUiModeStore } from '../../stores/uiModeStore';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useKeyboardVisible } from '../../hooks/useKeyboardVisible';
@@ -71,6 +65,13 @@ export const computeFooterPaddingBottom = (
   // Thin overlay inset: keep the symmetric-with-top cap.
   return Math.min(insetBottom, FOOTER_SAFE_CAP);
 };
+
+const keyExtractor = (item: { id: string }) => item.id;
+const MAINTAIN_VISIBLE_CONTENT_POSITION = {
+  minIndexForVisible: 0,
+  autoscrollToTopThreshold: 100,
+};
+const REMOVE_CLIPPED_SUBVIEWS = Platform.OS !== 'android';
 
 // Show the "tap to continue" bar only when a text reply is genuinely PENDING — the
 // selected text model was evicted AND the last message is an unanswered user turn.
@@ -216,6 +217,31 @@ export const ChatMessageArea: React.FC<ChatMessageAreaProps> = ({
   const handleRepairVision = activeModelRepoId
     ? () => tabNav.navigate('DownloadManager')
     : undefined;
+  const handleContentSizeChange = React.useCallback(
+    (_width: number, height: number) => {
+      if (!hasScrolledRef.current && height > 0) {
+        flatListRef.current?.scrollToEnd({ animated: false });
+        hasScrolledRef.current = true;
+      } else if (isNearBottomRef.current) {
+        flatListRef.current?.scrollToEnd({ animated: false });
+      }
+    },
+    [flatListRef, isNearBottomRef],
+  );
+  const handleListLayout = React.useCallback(
+    (event: { nativeEvent: { layout: { height: number } } }) => {
+      const newHeight = event.nativeEvent.layout.height;
+      const previousHeight = flatListHeightRef.current;
+      flatListHeightRef.current = newHeight;
+      if (previousHeight > 0 && newHeight < previousHeight) {
+        setTimeout(
+          () => flatListRef.current?.scrollToEnd({ animated: true }),
+          50,
+        );
+      }
+    },
+    [flatListRef],
+  );
   const scrollToBottomStyle = useMemo(
     () => [styles.scrollToBottomContainer, { bottom: inputHeight + 8 }],
     [styles.scrollToBottomContainer, inputHeight],
@@ -246,39 +272,17 @@ export const ChatMessageArea: React.FC<ChatMessageAreaProps> = ({
           ref={flatListRef}
           data={chat.displayMessages}
           renderItem={renderItem}
-          keyExtractor={item => item.id}
+          keyExtractor={keyExtractor}
           extraData={interfaceMode}
           contentContainerStyle={styles.messageList}
           onScroll={handleScroll}
-          onContentSizeChange={(_w, h) => {
-            if (!hasScrolledRef.current && h > 0) {
-              // Initial layout: force scroll to bottom regardless of isNearBottom
-              flatListRef.current?.scrollToEnd({ animated: false });
-              hasScrolledRef.current = true;
-            } else if (isNearBottomRef.current) {
-              flatListRef.current?.scrollToEnd({ animated: false });
-            }
-          }}
-          onLayout={e => {
-            const newHeight = e.nativeEvent.layout.height;
-            const prevHeight = flatListHeightRef.current;
-            flatListHeightRef.current = newHeight;
-            if (prevHeight > 0 && newHeight < prevHeight) {
-              setTimeout(
-                () => flatListRef.current?.scrollToEnd({ animated: true }),
-                50,
-              );
-            }
-          }}
+          onContentSizeChange={handleContentSizeChange}
+          onLayout={handleListLayout}
           scrollEventThrottle={16}
           keyboardDismissMode="on-drag"
           keyboardShouldPersistTaps="handled"
-          onTouchStart={() => Keyboard.dismiss()}
-          maintainVisibleContentPosition={{
-            minIndexForVisible: 0,
-            autoscrollToTopThreshold: 100,
-          }}
-          removeClippedSubviews={Platform.OS !== 'android'}
+          maintainVisibleContentPosition={MAINTAIN_VISIBLE_CONTENT_POSITION}
+          removeClippedSubviews={REMOVE_CLIPPED_SUBVIEWS}
         />
       )}
       {chat.showScrollToBottom && chat.displayMessages.length > 0 && (

--- a/src/screens/ChatScreen/MessageRenderer.tsx
+++ b/src/screens/ChatScreen/MessageRenderer.tsx
@@ -8,6 +8,8 @@ import { Message } from '../../types';
 import { useUiModeStore } from '../../stores';
 import { getSlot, SLOTS } from '../../bootstrap/slotRegistry';
 import { ChatMessageItem } from './useChatScreen';
+import { STREAMING_MESSAGE_ID } from './types';
+import { useActiveStreamText } from './useActiveStreamText';
 
 type MessageRendererProps = {
   item: Message | ChatMessageItem;
@@ -160,7 +162,32 @@ export function messageRendererPropsEqual(
   );
 }
 
-export const MessageRenderer = React.memo(
+const CommittedMessageRenderer = React.memo(
   MessageRendererInner,
+  messageRendererPropsEqual,
+);
+
+const LiveStreamMessageRenderer: React.FC<MessageRendererProps> = props => {
+  const live = useActiveStreamText();
+  const item = React.useMemo(
+    () => ({
+      ...props.item,
+      content: live.content,
+      reasoningContent: live.reasoningContent,
+    }),
+    [props.item, live],
+  );
+  return <CommittedMessageRenderer {...props} item={item} />;
+};
+
+const MessageRendererDispatch: React.FC<MessageRendererProps> = props =>
+  props.item.id === STREAMING_MESSAGE_ID ? (
+    <LiveStreamMessageRenderer {...props} />
+  ) : (
+    <CommittedMessageRenderer {...props} />
+  );
+
+export const MessageRenderer = React.memo(
+  MessageRendererDispatch,
   messageRendererPropsEqual,
 );

--- a/src/screens/ChatScreen/index.tsx
+++ b/src/screens/ChatScreen/index.tsx
@@ -23,7 +23,10 @@ import type { Conversation, Message } from '../../types';
 import { useTheme, useThemedStyles } from '../../theme';
 import { createStyles } from './styles';
 import { useChatScreen } from './useChatScreen';
-import { MessageRenderer } from './MessageRenderer';
+import {
+  useChatRowRenderer,
+  useChatScrollTracker,
+} from './useChatListCallbacks';
 import { NoModelScreen, ChatHeader } from './ChatScreenComponents';
 import { ChatModalSection } from './ChatModalSection';
 import { ChatMessageArea } from './ChatMessageArea';
@@ -90,14 +93,14 @@ export const ChatScreen: React.FC = () => {
         'Eject All Models',
         'Unload all active models to free up memory?',
         [
-      { text: 'Cancel', style: 'cancel' },
-      {
+          { text: 'Cancel', style: 'cancel' },
+          {
             text: 'Eject',
             style: 'destructive',
-        onPress: async () => {
-          chat.setAlertState(hideAlert());
-          try {
-            const count = await ejectAll();
+            onPress: async () => {
+              chat.setAlertState(hideAlert());
+              try {
+                const count = await ejectAll();
                 if (count > 0)
                   chat.setAlertState(
                     showAlert(
@@ -105,13 +108,13 @@ export const ChatScreen: React.FC = () => {
                       `Unloaded ${count} model${count > 1 ? 's' : ''}`,
                     ),
                   );
-          } catch {
+              } catch {
                 chat.setAlertState(
                   showAlert('Error', 'Failed to unload models'),
                 );
-          }
-        },
-      },
+              }
+            },
+          },
         ],
       ),
     );
@@ -143,9 +146,9 @@ export const ChatScreen: React.FC = () => {
   useEffect(
     () =>
       subscribeProPrompt(() => {
-    if (proAhaShownThisSession.current) return;
-    proAhaShownThisSession.current = true;
-    setProAhaVisible(true);
+        if (proAhaShownThisSession.current) return;
+        proAhaShownThisSession.current = true;
+        setProAhaVisible(true);
       }),
     [],
   );
@@ -182,8 +185,14 @@ export const ChatScreen: React.FC = () => {
         flatListRef.current?.scrollToEnd({ animated: false });
       }, 300);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [interfaceMode]);
+
+  const handleScroll = useChatScrollTracker(
+    isNearBottomRef,
+    chat.setShowScrollToBottom,
+  );
+  const renderItem = useChatRowRenderer(chat);
 
   const alertEl = (
     <CustomAlert
@@ -217,32 +226,6 @@ export const ChatScreen: React.FC = () => {
   // Model loading is shown inline (a "Loading model" bar above the input via
   // ChatMessageArea), so the chat stays visible while a text/image model loads —
   // no full-screen takeover.
-
-  const handleScroll = (event: any) => {
-    const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
-    const distFromBottom =
-      contentSize.height - layoutMeasurement.height - contentOffset.y;
-    isNearBottomRef.current = distFromBottom < 100;
-    chat.setShowScrollToBottom(!isNearBottomRef.current);
-  };
-
-  const renderItem = ({ item, index }: { item: any; index: number }) => (
-    <MessageRenderer
-      item={item}
-      index={index}
-      displayMessagesLength={chat.displayMessages.length}
-      animateLastN={chat.animateLastN}
-      imageModelLoaded={chat.imageModelLoaded}
-      isStreaming={chat.isStreaming}
-      isGeneratingImage={chat.isGeneratingImage}
-      showGenerationDetails={chat.settings.showGenerationDetails}
-      onCopy={chat.handleCopyMessage}
-      onRetry={chat.handleRetryMessage}
-      onEdit={chat.handleEditMessage}
-      onGenerateImage={chat.handleGenerateImageFromMessage}
-      onImagePress={chat.handleImagePress}
-    />
-  );
 
   const imageCount = countConversationImages(chat.activeConversation);
 

--- a/src/screens/ChatScreen/types.ts
+++ b/src/screens/ChatScreen/types.ts
@@ -107,10 +107,13 @@ function groupSupportingContextWithImage(
  */
 export type RemoteStreamItem = ChatStreamPreviewRow;
 
+export const STREAMING_MESSAGE_ID = 'streaming';
+
 export type StreamingState = {
   isThinking: boolean;
   streamingMessage: string;
   streamingReasoningContent: string;
+  hasStreamingText?: boolean;
   isStreamingForThisConversation: boolean;
   isModelLoading?: boolean;
   loadingModelName?: string;
@@ -268,7 +271,9 @@ function localDisplayMessages(
     ];
   }
   if (
-    (streamingMessage || streamingReasoningContent) &&
+    (streamingMessage ||
+      streamingReasoningContent ||
+      streaming.hasStreamingText) &&
     isStreamingForThisConversation
   ) {
     if (_lastDisplayBranch !== 'streaming') {
@@ -277,7 +282,7 @@ function localDisplayMessages(
     return [
       ...allMessages,
       {
-        id: 'streaming',
+        id: STREAMING_MESSAGE_ID,
         role: 'assistant' as const,
         content: streamingMessage,
         reasoningContent: streamingReasoningContent || undefined,

--- a/src/screens/ChatScreen/useActiveStreamText.ts
+++ b/src/screens/ChatScreen/useActiveStreamText.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+import { useChatStore } from '../../stores';
+
+export type ActiveStreamText = {
+  content: string;
+  reasoningContent?: string;
+};
+
+/** The only subscription that reads per-token local reply text. */
+export function useActiveStreamText(): ActiveStreamText {
+  const content = useChatStore(state => state.streamingMessage);
+  const reasoning = useChatStore(state => state.streamingReasoningContent);
+  return useMemo(
+    () => ({ content, reasoningContent: reasoning || undefined }),
+    [content, reasoning],
+  );
+}
+
+/** Let the screen add one stable live row without reading its changing text. */
+export function useHasActiveStreamText(): boolean {
+  return useChatStore(
+    state =>
+      state.streamingMessage.length > 0 ||
+      state.streamingReasoningContent.length > 0,
+  );
+}

--- a/src/screens/ChatScreen/useChatGenerationActions.ts
+++ b/src/screens/ChatScreen/useChatGenerationActions.ts
@@ -28,6 +28,7 @@ import { ensureDefaultClassifier } from '../../services/classifierProvisioning';
 import { abortPreload } from '../../services/modelPreloader';
 import { modelResidencyManager } from '../../services/modelResidency';
 import { reportModelFailure } from '../../services/modelFailureHandler';
+import { isOverridableMemoryError } from '../../services/modelLoadErrors';
 import { remoteToolCapabilityIssue } from '../../services/toolCapabilityPreflight';
 import { embeddingService } from '../../services/rag/embedding';
 import {
@@ -47,8 +48,29 @@ import {
 } from '../../types';
 import logger from '../../utils/logger';
 import { ModelReadyOutcome, ensureReadyOrAlert } from './modelReadiness';
+import {
+  CONTINUE_ACTIVE_TURN_INSTRUCTION,
+  contextCompactedNoticeText,
+} from '@offgrid/models';
 type SetState<T> = Dispatch<SetStateAction<T>>;
 const FALLBACK_RECENT_MESSAGE_COUNT = 2;
+
+function offerMemoryRefusalRetry(
+  deps: GenerationDeps,
+  request: { conversationId: string; error: unknown; retry: () => void },
+): boolean {
+  if (!isOverridableMemoryError(request.error)) return false;
+  reportModelFailure('text', request.error, {
+    id: `text-memory-${request.conversationId}`,
+    onLoadAnyway: () => {
+      modelResidencyManager.rememberSessionOverride(
+        deps.activeModelInfo?.modelId ?? undefined,
+      );
+      request.retry();
+    },
+  });
+  return true;
+}
 
 export type GenerationDeps = {
   activeModelId: string | null;
@@ -514,20 +536,67 @@ async function generateWithCompactionRetry(
     // generationService.stopGeneration(): this is mid-turn, and the owner's stop persists the partial and
     // resets state, which would end the turn the retry below is about to continue.
     await stopAllTextEngines().catch(() => {});
-    const conversation = useChatStore
-      .getState()
-      .conversations.find(c => c.id === opts.id);
+    const chatState = useChatStore.getState();
+    const conversation = chatState.conversations.find(c => c.id === opts.id);
     const previousSummary = conversation?.compactionSummary;
+    // Compact the prompt that actually failed. It can already start with a prior
+    // summary and omit rows before its cutoff, so rebuilding from the full stored
+    // conversation would reintroduce history the active prompt no longer contains.
+    const promptMessages = opts.messages.filter(
+      message => message.role !== 'system' && !message.isSystemInfo,
+    );
+    const promptIds = new Set(promptMessages.map(message => message.id));
+    const storedMessages = (conversation?.messages ?? []).filter(
+      message => !message.isSystemInfo,
+    );
+    const cutoffIndex = conversation?.compactionCutoffMessageId
+      ? storedMessages.findIndex(
+          message => message.id === conversation.compactionCutoffMessageId,
+        )
+      : -1;
+    const committedDuringAttempt = storedMessages
+      .slice(cutoffIndex + 1)
+      .filter(message => !promptIds.has(message.id));
+    const committedMessages = [...promptMessages, ...committedDuringAttempt];
+    const systemMessage = opts.messages.find(
+      message => message.role === 'system',
+    );
+    const exactMessages: Message[] = [
+      ...(systemMessage ? [systemMessage] : []),
+      ...committedMessages,
+    ];
+    const visiblePartial =
+      chatState.streamingForConversationId === opts.id
+        ? chatState.streamingMessage
+        : '';
+    if (
+      visiblePartial.trim() &&
+      committedMessages.at(-1)?.content !== visiblePartial
+    ) {
+      exactMessages.push({
+        id: chatState.streamingMessageUuid ?? 'active-partial',
+        role: 'assistant',
+        content: visiblePartial,
+        reasoningContent: chatState.streamingReasoningContent || undefined,
+        timestamp: Date.now(),
+      });
+    }
+    const lastUserIndex = exactMessages
+      .map(message => message.role)
+      .lastIndexOf('user');
+    const protectedTailCount =
+      lastUserIndex < 0 ? 1 : exactMessages.length - lastUserIndex;
     const compacted = await contextCompactionService
       .compact({
         conversationId: opts.id,
         systemPrompt: opts.prompt,
-        allMessages: opts.messages,
+        allMessages: exactMessages,
         previousSummary,
+        protectedTailCount,
       })
       .catch(async () => {
         await llmService.clearKVCache(true).catch(() => {});
-        const recent = opts.messages
+        const recent = exactMessages
           .filter(m => m.role !== 'system')
           .slice(-FALLBACK_RECENT_MESSAGE_COUNT);
         return [
@@ -543,7 +612,23 @@ async function generateWithCompactionRetry(
     // Stop/Eject can arrive while the summary is running. Do not start a new
     // completion after the owner has cancelled this turn.
     if (generationService.wasAborted()) return true;
-    const retryOutcome = await gen(compacted);
+    useChatStore.getState().addMessage(opts.id, {
+      role: 'assistant',
+      content: contextCompactedNoticeText(
+        exactMessages.filter(message => message.role !== 'system').length,
+        compacted.filter(message => message.role !== 'system').length,
+      ),
+      isSystemInfo: true,
+    });
+    const retryOutcome = await gen([
+      ...compacted,
+      {
+        id: 'continue-active-turn',
+        role: 'system',
+        content: CONTINUE_ACTIVE_TURN_INSTRUCTION,
+        timestamp: 0,
+      },
+    ]);
     turnInterrupted = !!(retryOutcome as { interrupted?: boolean } | void)
       ?.interrupted;
   }
@@ -708,6 +793,18 @@ export async function startGenerationFn(
       conversation?.projectId,
     );
   } catch (error: any) {
+    if (
+      offerMemoryRefusalRetry(deps, {
+        conversationId: targetConversationId,
+        error,
+        retry: () => {
+          void startGenerationFn(deps, call);
+        },
+      })
+    ) {
+      generationSession.end('error');
+      return;
+    }
     const msg =
       error?.message || error?.toString?.() || 'Failed to generate response';
     logger.error('[ChatGen] Generation failed:', msg, error);
@@ -1145,6 +1242,18 @@ export async function regenerateResponseFn(
       conversation?.projectId,
     );
   } catch (error: any) {
+    if (
+      offerMemoryRefusalRetry(deps, {
+        conversationId: targetConversationId,
+        error,
+        retry: () => {
+          void regenerateResponseFn(deps, call);
+        },
+      })
+    ) {
+      generationSession.end('error');
+      return;
+    }
     const msg = error?.message || 'Failed to generate response';
     const isContextOverflow =
       msg.includes('too long') ||

--- a/src/screens/ChatScreen/useChatListCallbacks.tsx
+++ b/src/screens/ChatScreen/useChatListCallbacks.tsx
@@ -1,0 +1,87 @@
+import React, { useCallback, useMemo, useRef } from 'react';
+import type { Message } from '../../types';
+import { MessageRenderer } from './MessageRenderer';
+import type { useChatScreen } from './useChatScreen';
+
+type Chat = ReturnType<typeof useChatScreen>;
+export type ChatRowRenderer = (info: {
+  item: any;
+  index: number;
+}) => React.JSX.Element;
+
+/** Keep FlatList callback identities stable while one streamed row changes. */
+export function useChatRowRenderer(chat: Chat): ChatRowRenderer {
+  const handlersRef = useRef({
+    onCopy: chat.handleCopyMessage,
+    onRetry: chat.handleRetryMessage,
+    onEdit: chat.handleEditMessage,
+    onGenerateImage: chat.handleGenerateImageFromMessage,
+    onImagePress: chat.handleImagePress,
+  });
+  handlersRef.current = {
+    onCopy: chat.handleCopyMessage,
+    onRetry: chat.handleRetryMessage,
+    onEdit: chat.handleEditMessage,
+    onGenerateImage: chat.handleGenerateImageFromMessage,
+    onImagePress: chat.handleImagePress,
+  };
+  const handlers = useMemo(
+    () => ({
+      onCopy: (content: string) => handlersRef.current.onCopy(content),
+      onRetry: (message: Message) => handlersRef.current.onRetry(message),
+      onEdit: (message: Message, newContent: string) =>
+        handlersRef.current.onEdit(message, newContent),
+      onGenerateImage: (prompt: string) =>
+        handlersRef.current.onGenerateImage(prompt),
+      onImagePress: (uri: string) => handlersRef.current.onImagePress(uri),
+    }),
+    [],
+  );
+
+  const displayMessagesLength = chat.displayMessages.length;
+  const showGenerationDetails = chat.settings.showGenerationDetails;
+  const { animateLastN, imageModelLoaded, isStreaming, isGeneratingImage } =
+    chat;
+
+  return useCallback(
+    ({ item, index }) => (
+      <MessageRenderer
+        item={item}
+        index={index}
+        displayMessagesLength={displayMessagesLength}
+        animateLastN={animateLastN}
+        imageModelLoaded={imageModelLoaded}
+        isStreaming={isStreaming}
+        isGeneratingImage={isGeneratingImage}
+        showGenerationDetails={showGenerationDetails}
+        {...handlers}
+      />
+    ),
+    [
+      displayMessagesLength,
+      animateLastN,
+      imageModelLoaded,
+      isStreaming,
+      isGeneratingImage,
+      showGenerationDetails,
+      handlers,
+    ],
+  );
+}
+
+export function useChatScrollTracker(
+  isNearBottomRef: React.MutableRefObject<boolean>,
+  setShowScrollToBottom: (show: boolean) => void,
+): (event: any) => void {
+  return useCallback(
+    (event: any) => {
+      const { contentOffset, contentSize, layoutMeasurement } =
+        event.nativeEvent;
+      const distanceFromBottom =
+        contentSize.height - layoutMeasurement.height - contentOffset.y;
+      isNearBottomRef.current = distanceFromBottom < 100;
+      setShowScrollToBottom(!isNearBottomRef.current);
+    },
+    [isNearBottomRef, setShowScrollToBottom],
+  );
+}

--- a/src/screens/ChatScreen/useChatScreen.ts
+++ b/src/screens/ChatScreen/useChatScreen.ts
@@ -14,6 +14,7 @@ import {
 } from '../../stores';
 import { useSyncIdentityStore } from '../../stores/syncIdentityStore';
 import { useRemoteChatStreamPreviews } from './useRemoteChatStreamPreviews';
+import { useHasActiveStreamText } from './useActiveStreamText';
 import { useActiveTextModel } from '../../hooks/useActiveTextModel';
 import { hardwareService } from '../../services';
 import { useGeneratingConversationId } from '../../hooks/useGenerationSession';
@@ -63,8 +64,7 @@ export const useChatScreen = () => {
   const isModelLoading = useChatStore(state => state.isModelLoading);
   const setIsModelLoading = useChatStore(state => state.setIsModelLoading);
   const setLoadingModelName = useChatStore(state => state.setLoadingModelName);
-  const [loadingModel, setLoadingModelState] =
-    useState<DownloadedModel | null>(null);
+  const [loadingModel, setLoadingModelState] = useState<DownloadedModel | null>(null);
   const setLoadingModel = useCallback(
     (model: DownloadedModel | null) => {
       setLoadingModelState(model);
@@ -84,9 +84,7 @@ export const useChatScreen = () => {
   const [viewerImageUri, setViewerImageUri] = useState<string | null>(null);
   const [supportsToolCalling, setSupportsToolCalling] = useState(false);
   const [supportsThinking, setSupportsThinking] = useState(false);
-  const [pendingProjectId, setPendingProjectId] = useState<string | undefined>(
-    route.params?.projectId,
-  );
+  const [pendingProjectId, setPendingProjectId] = useState<string | undefined>(route.params?.projectId);
   // Owned by the generationSession service (single owner); observed reactively here.
   const generatingConversationId = useGeneratingConversationId();
   // Stashed when the model selector opens with no text model; replayed on pick.
@@ -95,27 +93,22 @@ export const useChatScreen = () => {
     attachments?: MediaAttachment[];
   } | null>(null);
   const modelLoadStartTimeRef = useRef<number | null>(null);
-  const startGenerationRef = useRef<
-    (id: string, text: string) => Promise<void>
-  >(null);
+  const startGenerationRef = useRef<(id: string, text: string) => Promise<void>>(null);
   const genDepsRef = useRef<GenerationDeps | null>(null);
   useChatAudioLifecycle(navigation);
-  const { imageGenState, isCompacting, queueCount, queuedTexts } =
-    useChatRuntimeSubscriptions(genDepsRef, startGenerationRef);
+  const { imageGenState, isCompacting, queueCount, queuedTexts } = useChatRuntimeSubscriptions(genDepsRef, startGenerationRef);
 
-  const {
-    activeModelId,
-    downloadedModels,
-    settings,
-    activeImageModelId,
-    downloadedImageModels,
-    setDownloadedImageModels,
-    setIsGeneratingImage: setAppIsGeneratingImage,
-    setImageGenerationStatus: setAppImageGenerationStatus,
-    removeImagesByConversationId,
-    loadedSettings,
-    textModelEvicted,
-  } = useAppStore();
+  const activeModelId = useAppStore(state => state.activeModelId);
+  const downloadedModels = useAppStore(state => state.downloadedModels);
+  const settings = useAppStore(state => state.settings);
+  const activeImageModelId = useAppStore(state => state.activeImageModelId);
+  const downloadedImageModels = useAppStore(state => state.downloadedImageModels);
+  const setDownloadedImageModels = useAppStore(state => state.setDownloadedImageModels);
+  const setAppIsGeneratingImage = useAppStore(state => state.setIsGeneratingImage);
+  const setAppImageGenerationStatus = useAppStore(state => state.setImageGenerationStatus);
+  const removeImagesByConversationId = useAppStore(state => state.removeImagesByConversationId);
+  const loadedSettings = useAppStore(state => state.loadedSettings);
+  const textModelEvicted = useAppStore(state => state.textModelEvicted);
 
   // Remote model state - use proper selectors for reactivity
   const activeServerId = useRemoteServerStore(s => s.activeServerId);
@@ -124,26 +117,24 @@ export const useChatScreen = () => {
   );
   const discoveredModels = useRemoteServerStore(s => s.discoveredModels);
 
-  const {
-    activeConversationId,
-    conversations,
-    createConversation,
-    addMessage,
-    updateMessageContent,
-    updateMessageTurnKind,
-    deleteMessagesAfter,
-    streamingMessage,
-    streamingReasoningContent,
-    streamingForConversationId,
-    isStreaming,
-    isThinking,
-    clearStreamingMessage,
-    deleteConversation,
-    setActiveConversation,
-    setConversationProject,
-  } = useChatStore();
+  const activeConversationId = useChatStore(state => state.activeConversationId);
+  const conversations = useChatStore(state => state.conversations);
+  const createConversation = useChatStore(state => state.createConversation);
+  const addMessage = useChatStore(state => state.addMessage);
+  const updateMessageContent = useChatStore(state => state.updateMessageContent);
+  const updateMessageTurnKind = useChatStore(state => state.updateMessageTurnKind);
+  const deleteMessagesAfter = useChatStore(state => state.deleteMessagesAfter);
+  const streamingForConversationId = useChatStore(state => state.streamingForConversationId);
+  const isStreaming = useChatStore(state => state.isStreaming);
+  const isThinking = useChatStore(state => state.isThinking);
+  const hasStreamingText = useHasActiveStreamText();
+  const clearStreamingMessage = useChatStore(state => state.clearStreamingMessage);
+  const deleteConversation = useChatStore(state => state.deleteConversation);
+  const setActiveConversation = useChatStore(state => state.setActiveConversation);
+  const setConversationProject = useChatStore(state => state.setConversationProject);
 
-  const { projects, getProject } = useProjectStore();
+  const projects = useProjectStore(state => state.projects);
+  const getProject = useProjectStore(state => state.getProject);
 
   const activeConversation = conversations.find(
     c => c.id === activeConversationId,
@@ -298,19 +289,29 @@ export const useChatScreen = () => {
   // Replies generating on paired devices. Empty unless Pro's chat-stream service is running.
   const remotePreviews = useRemoteChatStreamPreviews(activeConversationId);
   const localDeviceId = useSyncIdentityStore(s => s.localDeviceId);
-  const displayMessages = getDisplayMessages(
-    activeConversation?.messages || [],
-    {
+  const displayMessages = useMemo(() => getDisplayMessages(activeConversation?.messages || [], {
+    isThinking,
+    streamingMessage: '',
+    streamingReasoningContent: '',
+    hasStreamingText,
+    isStreamingForThisConversation,
+    isModelLoading,
+    loadingModelName: loadingModel?.name,
+    isGeneratingForThisConversation,
+    remotePreviews,
+    localDeviceId,
+  }),
+    [
+      activeConversation?.messages,
       isThinking,
-      streamingMessage,
-      streamingReasoningContent,
+      hasStreamingText,
       isStreamingForThisConversation,
       isModelLoading,
-      loadingModelName: loadingModel?.name,
+      loadingModel?.name,
       isGeneratingForThisConversation,
       remotePreviews,
       localDeviceId,
-    },
+    ],
   );
 
   const animateLastN = useChatPresentationLifecycle(

--- a/src/screens/HomeScreen/hooks/useHomeScreen.ts
+++ b/src/screens/HomeScreen/hooks/useHomeScreen.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { InteractionManager } from 'react-native';
 import {
   AlertState,
@@ -88,8 +88,9 @@ export const useHomeScreen = (navigation: HomeScreenNavigationProp) => {
     generatedImages,
   } = useAppStore();
 
-  const { conversations, setActiveConversation, deleteConversation } =
-    useChatStore();
+  const conversations = useChatStore(state => state.conversations);
+  const setActiveConversation = useChatStore(state => state.setActiveConversation);
+  const deleteConversation = useChatStore(state => state.deleteConversation);
 
   // Remote server store for remote models
   const {
@@ -354,7 +355,10 @@ export const useHomeScreen = (navigation: HomeScreenNavigationProp) => {
     null;
   // Ordered, not just the store's first four - otherwise "Recent" can list older chats than
   // the ones just used, and disagrees with the Chats list and desktop.
-  const recentConversations = mostRecentConversations(conversations, 4);
+  const recentConversations = useMemo(
+    () => mostRecentConversations(conversations, 4),
+    [conversations],
+  );
 
   // Get all remote text models — includes vision-language models since they do text generation too
   const remoteTextModels: RemoteModel[] = remoteServers.flatMap(

--- a/src/screens/ProjectChatsScreen.tsx
+++ b/src/screens/ProjectChatsScreen.tsx
@@ -155,9 +155,13 @@ export const ProjectChatsScreen: React.FC = () => {
   const styles = useThemedStyles(createStyles);
   const [alertState, setAlertState] = useState<AlertState>(initialAlertState);
 
-  const { getProject } = useProjectStore();
-  const { conversations, deleteConversation, setActiveConversation, createConversation } = useChatStore();
-  const { downloadedModels, activeModelId } = useAppStore();
+  const getProject = useProjectStore(state => state.getProject);
+  const conversations = useChatStore(state => state.conversations);
+  const deleteConversation = useChatStore(state => state.deleteConversation);
+  const setActiveConversation = useChatStore(state => state.setActiveConversation);
+  const createConversation = useChatStore(state => state.createConversation);
+  const downloadedModels = useAppStore(state => state.downloadedModels);
+  const activeModelId = useAppStore(state => state.activeModelId);
 
   const project = getProject(projectId);
   const hasModels = downloadedModels.length > 0;

--- a/src/screens/ProjectDetailScreen.tsx
+++ b/src/screens/ProjectDetailScreen.tsx
@@ -35,14 +35,14 @@ export const ProjectDetailScreen: React.FC = () => {
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
 
-  const { getProject, deleteProject } = useProjectStore();
-  const {
-    conversations,
-    deleteConversation,
-    setActiveConversation,
-    createConversation,
-  } = useChatStore();
-  const { downloadedModels, activeModelId } = useAppStore();
+  const getProject = useProjectStore(state => state.getProject);
+  const deleteProject = useProjectStore(state => state.deleteProject);
+  const conversations = useChatStore(state => state.conversations);
+  const deleteConversation = useChatStore(state => state.deleteConversation);
+  const setActiveConversation = useChatStore(state => state.setActiveConversation);
+  const createConversation = useChatStore(state => state.createConversation);
+  const downloadedModels = useAppStore(state => state.downloadedModels);
+  const activeModelId = useAppStore(state => state.activeModelId);
 
   const project = getProject(projectId);
   const hasModels = downloadedModels.length > 0;

--- a/src/screens/ProjectsScreen.tsx
+++ b/src/screens/ProjectsScreen.tsx
@@ -36,8 +36,9 @@ export const ProjectsScreen: React.FC = () => {
   const focusTrigger = useFocusTrigger();
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
-  const { projects, deleteProject } = useProjectStore();
-  const { conversations } = useChatStore();
+  const projects = useProjectStore(state => state.projects);
+  const deleteProject = useProjectStore(state => state.deleteProject);
+  const conversations = useChatStore(state => state.conversations);
   const [alertState, setAlertState] = useState<AlertState>(initialAlertState);
 
   // Get chat count for a project

--- a/src/services/contextCompaction.ts
+++ b/src/services/contextCompaction.ts
@@ -14,26 +14,14 @@
  *   Native overhead 5%      (template, tools, and media)
  */
 import { llmService } from './llm';
-import { CONTEXT_PROMPT_BUDGET_RATIO } from './llmHelpers';
 import { useChatStore } from '../stores/chatStore';
 import { Message } from '../types';
 import logger from '../utils/logger';
-
-const CONTEXT_FULL_PATTERNS = [
-  'context is full',
-  'not enough context space',
-  'context window exceeded',
-  'context length exceeded',
-];
-
-/** Fraction of context allocated to the summary */
-const SUMMARY_BUDGET_RATIO = 0.12;
-
-/** Fallback chars-per-token when tokenizer is unavailable */
-const CHARS_PER_TOKEN_ESTIMATE = 4;
-
-/** Estimated token overhead for the summarization instruction prompt */
-const SUMMARIZER_INSTRUCTION_OVERHEAD_TOKENS = 100;
+import {
+  isContextCapacityError,
+  planContextCompaction,
+  CHARS_PER_TOKEN_ESTIMATE,
+} from '@offgrid/models';
 
 /** System prompt for the summarizer LLM call */
 const SUMMARIZER_SYSTEM_PROMPT =
@@ -43,7 +31,9 @@ class ContextCompactionService {
   private _isCompacting = false;
   private readonly compactingListeners = new Set<(v: boolean) => void>();
 
-  get isCompacting(): boolean { return this._isCompacting; }
+  get isCompacting(): boolean {
+    return this._isCompacting;
+  }
 
   subscribeCompacting(listener: (v: boolean) => void): () => void {
     this.compactingListeners.add(listener);
@@ -62,8 +52,7 @@ class ContextCompactionService {
   }
 
   isContextFullError(error: unknown): boolean {
-    const msg = (error instanceof Error ? error.message : `${error as string}`).toLowerCase();
-    return CONTEXT_FULL_PATTERNS.some(p => msg.includes(p));
+    return isContextCapacityError(error);
   }
 
   /** Count tokens for a string; falls back to char estimate if tokenizer unavailable */
@@ -85,43 +74,39 @@ class ContextCompactionService {
    *
    * Falls back to trim-only if summarization fails.
    */
-  async compact(
-    opts: { conversationId: string; systemPrompt: string; allMessages: Message[]; previousSummary?: string },
-  ): Promise<Message[]> {
-    const { conversationId, systemPrompt, allMessages, previousSummary } = opts;
+  async compact(opts: {
+    conversationId: string;
+    systemPrompt: string;
+    allMessages: Message[];
+    previousSummary?: string;
+    protectedTailCount?: number;
+  }): Promise<Message[]> {
+    const {
+      conversationId,
+      systemPrompt,
+      allMessages,
+      previousSummary,
+      protectedTailCount,
+    } = opts;
     this.setCompacting(true);
     try {
       await llmService.clearKVCache(true);
 
-      const ctxLength = llmService.getPerformanceSettings().contextLength || 2048;
-      const summaryTokenBudget = Math.floor(ctxLength * SUMMARY_BUDGET_RATIO);
-      const systemTokens = await this.countTokens(systemPrompt);
-      const recentTokenBudget = Math.max(0, Math.floor(ctxLength * CONTEXT_PROMPT_BUDGET_RATIO) - summaryTokenBudget - systemTokens);
-
-      const nonSystem = allMessages.filter(m => m.role !== 'system');
-      logger.log(`[ContextCompaction] ${nonSystem.length} messages, ctx=${ctxLength}, summaryBudget=${summaryTokenBudget}, recentBudget=${recentTokenBudget}`);
-
-      // Walk backwards — keep recent messages that fit in the recent budget
-      const recentMessages: Message[] = [];
-      let recentTokensUsed = 0;
-      for (let i = nonSystem.length - 1; i >= 0; i--) {
-        const msg = nonSystem[i];
-        const tokens = await this.countTokens(msg.content);
-        if (recentTokensUsed + tokens <= recentTokenBudget) {
-          recentMessages.unshift(msg);
-          recentTokensUsed += tokens;
-        } else if (recentMessages.length === 0) {
-          // Last message is too large — truncate to fit
-          const charBudget = recentTokenBudget * CHARS_PER_TOKEN_ESTIMATE;
-          recentMessages.unshift({ ...msg, content: msg.content.slice(-charBudget) });
-          break;
-        } else {
-          break;
-        }
-      }
-
-      // Everything before recent is "old"
-      const oldMessages = nonSystem.slice(0, nonSystem.length - recentMessages.length);
+      const ctxLength =
+        llmService.getPerformanceSettings().contextLength || 2048;
+      const plan = await planContextCompaction({
+        messages: allMessages,
+        systemPrompt,
+        contextLength: ctxLength,
+        protectedTailCount,
+        previousSummary,
+        countTokens: (text: string) => this.countTokens(text),
+      });
+      const { oldMessages, recentMessages, summaryTokenBudget, summaryInput } =
+        plan;
+      logger.log(
+        `[ContextCompaction] ${plan.beforeCount} messages, ctx=${ctxLength}, summaryBudget=${summaryTokenBudget}`,
+      );
 
       // If there are no old messages, no compaction needed
       if (oldMessages.length === 0) {
@@ -135,17 +120,25 @@ class ContextCompactionService {
       // Try to summarize old messages via LLM
       let summary: string | undefined;
       try {
-        summary = await this.summarizeMessages({ oldMessages, previousSummary, summaryTokenBudget });
+        summary = await this.summarizeMessages({
+          summaryInput,
+          summaryTokenBudget,
+        });
       } catch (e) {
-        logger.warn('[ContextCompaction] Summarization failed, falling back to trim-only:', e);
+        logger.warn(
+          '[ContextCompaction] Summarization failed, falling back to trim-only:',
+          e,
+        );
       }
 
       // Determine cutoff: the last old message ID
-      const cutoffMessageId = oldMessages[oldMessages.length - 1]?.id;
+      const cutoffMessageId = plan.cutoffMessageId;
 
       // Persist compaction state
       if (summary && cutoffMessageId) {
-        useChatStore.getState().updateCompactionState(conversationId, summary, cutoffMessageId);
+        useChatStore
+          .getState()
+          .updateCompactionState(conversationId, summary, cutoffMessageId);
       }
 
       // Build result
@@ -164,7 +157,11 @@ class ContextCompactionService {
 
       result.push(...recentMessages);
 
-      logger.log(`[ContextCompaction] Compacted: ${nonSystem.length} → ${recentMessages.length} messages + summary (${summary ? summary.length : 0} chars)`);
+      logger.log(
+        `[ContextCompaction] Compacted: ${plan.beforeCount} → ${
+          recentMessages.length
+        } messages + summary (${summary ? summary.length : 0} chars)`,
+      );
       return result;
     } finally {
       this.setCompacting(false);
@@ -172,29 +169,11 @@ class ContextCompactionService {
   }
 
   /** Summarize old messages using the LLM with a hard token cap. */
-  private async summarizeMessages(
-    opts: { oldMessages: Message[]; previousSummary?: string; summaryTokenBudget: number },
-  ): Promise<string> {
-    const { oldMessages, previousSummary, summaryTokenBudget } = opts;
-    // Format old messages as a transcript
-    const transcript = oldMessages
-      .map(m => `${m.role}: ${m.content.replaceAll(/^(\w+: )/gm, '>$1')}`)
-      .join('\n');
-
-    const preamble = previousSummary
-      ? `Previous summary:\n${previousSummary}\n\nNew messages to incorporate:\n`
-      : '';
-
-    // Cap transcript to fit within context alongside the summarize instruction
-    const ctxLength = llmService.getPerformanceSettings().contextLength || 2048;
-    const instructionOverhead = SUMMARIZER_INSTRUCTION_OVERHEAD_TOKENS;
-    const inputBudget = ctxLength - summaryTokenBudget - instructionOverhead;
-    const inputCharBudget = inputBudget * CHARS_PER_TOKEN_ESTIMATE;
-
-    let transcriptInput = preamble + transcript;
-    if (transcriptInput.length > inputCharBudget) {
-      transcriptInput = transcriptInput.slice(-inputCharBudget);
-    }
+  private async summarizeMessages(opts: {
+    summaryInput: string;
+    summaryTokenBudget: number;
+  }): Promise<string> {
+    const { summaryInput, summaryTokenBudget } = opts;
 
     const summaryMessages: Message[] = [
       {
@@ -206,17 +185,22 @@ class ContextCompactionService {
       {
         id: 'summarize-input',
         role: 'user',
-        content: transcriptInput,
+        content: summaryInput,
         timestamp: 0,
       },
     ];
 
-    return await llmService.generateWithMaxTokens(summaryMessages, summaryTokenBudget);
+    return await llmService.generateWithMaxTokens(
+      summaryMessages,
+      summaryTokenBudget,
+    );
   }
 
   /** Clear persisted compaction state when a conversation is deleted */
   clearSummary(conversationId: string): void {
-    useChatStore.getState().updateCompactionState(conversationId, undefined, undefined);
+    useChatStore
+      .getState()
+      .updateCompactionState(conversationId, undefined, undefined);
   }
 }
 

--- a/src/services/generationRemoteHelpers.ts
+++ b/src/services/generationRemoteHelpers.ts
@@ -111,7 +111,7 @@ export async function generateRemoteResponseImpl(
     if (failedServerId)
       useRemoteServerStore.getState().updateServerHealth(failedServerId, false);
     const local = providerRegistry.getProvider('local');
-    if (local?.isModelLoaded()) {
+    if (local?.isModelLoaded?.()) {
       svc.forceFlushTokens();
       chatStore.clearStreamingMessage();
       svc.state.streamingContent = '';

--- a/src/services/generationRemoteHelpers.ts
+++ b/src/services/generationRemoteHelpers.ts
@@ -7,6 +7,8 @@ import { useAppStore, useChatStore, useRemoteServerStore } from '../stores';
 import { runToolLoop } from './generationToolLoop';
 import type { GenerationOptions, CompletionResult } from './providers/types';
 import logger from '../utils/logger';
+import { providerRegistry } from './providers';
+import { fallbackNoticeText } from '@offgrid/models';
 import {
   FLUSH_INTERVAL_MS,
   buildGenerationMetaImpl,
@@ -38,7 +40,7 @@ export async function generateRemoteResponseImpl(
   // abortRequested is reset by the next generation's prepareGeneration().
   const { signal: generationSignal } = svc.currentRemoteAbortController;
 
-  const { temperature, maxTokens, topP, thinkingEnabled } =
+  const { temperature, maxTokens, topP, thinkingEnabled, reasoningBudget } =
     useAppStore.getState().settings;
   const options: GenerationOptions = {
     temperature,
@@ -46,61 +48,61 @@ export async function generateRemoteResponseImpl(
     topP,
     stopSequences: [],
     enableThinking: thinkingEnabled && provider.capabilities.supportsThinking,
+    reasoningBudget,
+  };
+
+  const callbacks = {
+    onToken: (token: string) => {
+      if (generationSignal.aborted) return;
+      if (!firstTokenReceived) {
+        firstTokenReceived = true;
+        svc.remoteTimeToFirstToken = svc.state.startTime
+          ? (Date.now() - svc.state.startTime) / 1000
+          : undefined;
+        svc.updateState({ isThinking: false });
+        onFirstToken?.();
+      }
+      svc.state.streamingContent += token;
+      svc.tokenBuffer += token;
+      if (!svc.flushTimer) {
+        svc.flushTimer = setTimeout(
+          () => svc.flushTokenBuffer(),
+          FLUSH_INTERVAL_MS,
+        );
+      }
+    },
+    onReasoning: (content: string) => {
+      if (generationSignal.aborted) return;
+      svc.reasoningBuffer += content;
+      svc.totalReasoningLength += content.length;
+      if (!svc.flushTimer) {
+        svc.flushTimer = setTimeout(
+          () => svc.flushTokenBuffer(),
+          FLUSH_INTERVAL_MS,
+        );
+      }
+    },
+    onComplete: (_result: CompletionResult) => {
+      if (generationSignal.aborted) return;
+      svc.forceFlushTokens();
+      const generationTime = svc.state.startTime
+        ? Date.now() - svc.state.startTime
+        : undefined;
+      chatStore.finalizeStreamingMessage(
+        conversationId,
+        generationTime,
+        buildGenerationMetaImpl(svc),
+      );
+      svc.checkSharePrompt();
+      svc.resetState();
+    },
+    onError: (error: Error) => {
+      throw error;
+    },
   };
 
   try {
-    await provider.generate(messages, options, {
-      onToken: (token: string) => {
-        if (generationSignal.aborted) return;
-        if (!firstTokenReceived) {
-          firstTokenReceived = true;
-          svc.remoteTimeToFirstToken = svc.state.startTime
-            ? (Date.now() - svc.state.startTime) / 1000
-            : undefined;
-          svc.updateState({ isThinking: false });
-          onFirstToken?.();
-        }
-        svc.state.streamingContent += token;
-        svc.tokenBuffer += token;
-        if (!svc.flushTimer) {
-          svc.flushTimer = setTimeout(
-            () => svc.flushTokenBuffer(),
-            FLUSH_INTERVAL_MS,
-          );
-        }
-      },
-      onReasoning: (content: string) => {
-        if (generationSignal.aborted) return;
-        svc.reasoningBuffer += content;
-        svc.totalReasoningLength += content.length;
-        if (!svc.flushTimer) {
-          svc.flushTimer = setTimeout(
-            () => svc.flushTokenBuffer(),
-            FLUSH_INTERVAL_MS,
-          );
-        }
-      },
-      onComplete: (_result: CompletionResult) => {
-        if (generationSignal.aborted) return;
-        svc.forceFlushTokens();
-        const generationTime = svc.state.startTime
-          ? Date.now() - svc.state.startTime
-          : undefined;
-        chatStore.finalizeStreamingMessage(
-          conversationId,
-          generationTime,
-          buildGenerationMetaImpl(svc),
-        );
-        svc.checkSharePrompt();
-        svc.resetState();
-      },
-      onError: (error: Error) => {
-        if (generationSignal.aborted) return;
-        logger.error('[GenerationService] Remote generation error:', error);
-        keepShownPartialOnError(svc, conversationId);
-        throw error;
-      },
-    });
+    await provider.generate(messages, options, callbacks);
   } catch (error) {
     if (generationSignal.aborted) return;
     logger.error('[GenerationService] Remote generation error:', error);
@@ -108,6 +110,43 @@ export async function generateRemoteResponseImpl(
     const failedServerId = useRemoteServerStore.getState().activeServerId;
     if (failedServerId)
       useRemoteServerStore.getState().updateServerHealth(failedServerId, false);
+    const local = providerRegistry.getProvider('local');
+    if (local?.isModelLoaded()) {
+      svc.forceFlushTokens();
+      chatStore.clearStreamingMessage();
+      svc.state.streamingContent = '';
+      svc.tokenBuffer = '';
+      svc.reasoningBuffer = '';
+      svc.remoteTimeToFirstToken = undefined;
+      firstTokenReceived = false;
+      chatStore.addMessage(conversationId, {
+        role: 'assistant',
+        content: fallbackNoticeText(
+          {
+            name:
+              useRemoteServerStore.getState().getActiveServer()?.name ??
+              'Remote model',
+          },
+          { name: local.getLoadedModelId() ?? 'Local model' },
+          error,
+        ),
+        isSystemInfo: true,
+      });
+      chatStore.startStreaming(conversationId);
+      svc.updateState({ isThinking: true, startTime: Date.now() });
+      svc.answeringModelName = local.getLoadedModelId() ?? 'Local model';
+      svc.answeringLocally = true;
+      await local.generate(
+        messages,
+        {
+          ...options,
+          enableThinking:
+            thinkingEnabled && local.capabilities.supportsThinking,
+        },
+        callbacks,
+      );
+      return;
+    }
     keepShownPartialOnError(svc, conversationId);
     throw error;
   } finally {

--- a/src/services/generationService.ts
+++ b/src/services/generationService.ts
@@ -62,6 +62,8 @@ class GenerationService {
   private queueProcessor: QueueProcessor | null = null;
   private currentRemoteAbortController: AbortController | null = null;
   private remoteTimeToFirstToken: number | undefined;
+  private answeringModelName: string | undefined;
+  private answeringLocally = false;
 
   // Token batching — collect tokens and flush to UI at a controlled rate
   private tokenBuffer: string = '';
@@ -366,6 +368,8 @@ class GenerationService {
     this.reasoningBuffer = '';
     this.totalReasoningLength = 0;
     this.remoteTimeToFirstToken = undefined;
+    this.answeringModelName = undefined;
+    this.answeringLocally = false;
     this.updateState({
       isGenerating: false,
       isThinking: false,

--- a/src/services/generationServiceHelpers.ts
+++ b/src/services/generationServiceHelpers.ts
@@ -103,12 +103,13 @@ function buildLiteRTMeta(
 
 export function buildGenerationMetaImpl(svc: any): GenerationMeta {
   const meta = buildBaseGenerationMeta(svc);
+  if (svc.answeringModelName) meta.modelName = svc.answeringModelName;
   const routed = svc.state?.routedToolNames;
   if (Array.isArray(routed) && routed.length > 0) meta.routedToolNames = routed;
   return meta;
 }
 function buildBaseGenerationMeta(svc: any): GenerationMeta {
-  if (svc.isUsingRemoteProvider()) {
+  if (svc.isUsingRemoteProvider() && !svc.answeringLocally) {
     const remoteStore = useRemoteServerStore.getState();
     const activeServer = remoteStore.getActiveServer();
     const contentLength =

--- a/src/services/generationToolLoop.ts
+++ b/src/services/generationToolLoop.ts
@@ -489,6 +489,7 @@ function remoteGenerateOnce(
     topP: settings.topP,
     tools,
     enableThinking: thinkingEnabled,
+    reasoningBudget: settings.reasoningBudget,
   };
   let _fullContent = '';
   let streamed = false;

--- a/src/services/llmHelpers.ts
+++ b/src/services/llmHelpers.ts
@@ -16,8 +16,6 @@ import { ensureNativeLogCapture, resetNativeLogCapture, recentNativeLog } from '
 import { HTP_ENABLED } from '../config/featureFlags';
 
 const RESPONSE_RESERVE = 512;
-/** Prompt compaction target. Output length is the user's model-aware maxTokens setting. */
-export const CONTEXT_PROMPT_BUDGET_RATIO = 0.55;
 const DEFAULT_THREADS = 4; // targets performance cores only; over-threading onto efficiency cores (A520) hurts
 const DEFAULT_BATCH = 512;
 const DEFAULT_GPU_LAYERS = Platform.OS === 'ios' ? 99 : 0;

--- a/src/services/llmHelpers.ts
+++ b/src/services/llmHelpers.ts
@@ -1,5 +1,9 @@
 import { initLlama, LlamaContext } from 'llama.rn';
-import { REASONING_BUDGET_AUTO, thinkingBudgetPayload } from '@offgrid/models';
+import {
+  REASONING_BUDGET_AUTO,
+  reasoningWireFragment,
+  resolveReasoningPlan,
+} from '@offgrid/models';
 import RNFS from 'react-native-fs';
 import { Platform } from 'react-native';
 import { APP_CONFIG } from '../constants';
@@ -292,7 +296,6 @@ export function supportsNativeThinking(context: LlamaContext | null): boolean {
   }
 }
 export function buildThinkingCompletionParams(enableThinking: boolean, isGemma4: boolean = false, reasoningBudget?: number): { enable_thinking: boolean; reasoning_format: 'none' | 'auto' | 'deepseek'; thinking_budget_tokens?: number } {
-  if (!enableThinking) return { enable_thinking: false, reasoning_format: 'none' };
   // Native-first (parse-once at the runtime boundary): Gemma 4 uses its own
   // <|channel>thought\n...<channel|> format, not DeepSeek's <think> tags. reasoning_format:'auto'
   // lets llama.cpp detect the model's chat_format and parse reasoning + tool calls NATIVELY —
@@ -304,7 +307,22 @@ export function buildThinkingCompletionParams(enableThinking: boolean, isGemma4:
   // The thinking-budget rule (and the llama.rn wire fragment) is the shared @offgrid/models
   // contract - desktop applies the same rule as reasoning_budget_tokens on llama-server. At the
   // budget the engine closes the thinking block and the answer still streams.
-  return { enable_thinking: true, reasoning_format: isGemma4 ? 'auto' : 'deepseek', ...thinkingBudgetPayload(true, reasoningBudget ?? REASONING_BUDGET_AUTO) };
+  const wire = reasoningWireFragment(resolveReasoningPlan({
+    enabled: enableThinking,
+    budgetTokens: reasoningBudget ?? REASONING_BUDGET_AUTO,
+  }, {
+    transport: 'llama-rn',
+    control: 'enable-thinking',
+    supportsTokenBudget: true,
+    reasoningFormat: isGemma4 ? 'auto' : 'deepseek',
+  }));
+  return {
+    enable_thinking: wire.enable_thinking ?? false,
+    reasoning_format: wire.reasoning_format ?? 'none',
+    ...(wire.thinking_budget_tokens
+      ? { thinking_budget_tokens: wire.thinking_budget_tokens }
+      : {}),
+  };
 }
 export function getStreamingDelta(nextValue: string | undefined, previousValue: string): string | undefined {
   if (!nextValue) return undefined;

--- a/src/services/providers/openAICompatibleProvider.ts
+++ b/src/services/providers/openAICompatibleProvider.ts
@@ -23,6 +23,11 @@ import type {
   OpenAIStreamState,
 } from './openAICompatibleTypes';
 import { remoteAuthorizationHeaders } from '../remoteTransportPolicy';
+import {
+  reasoningWireFragment,
+  resolveReasoningPlan,
+  type ReasoningMetadata,
+} from '@offgrid/models';
 
 export type { OpenAIChatMessage, OpenAIConfig } from './openAICompatibleTypes';
 
@@ -91,6 +96,24 @@ export class OpenAICompatibleProvider implements LLMProvider {
     options: GenerationOptions,
     thinkingEnabled: boolean
   ): Record<string, unknown> {
+    const reasoningMetadata: ReasoningMetadata = this.config.endpoint.includes('openrouter.ai')
+      ? {
+          transport: 'openrouter',
+          control: 'provider-native',
+          supportsTokenBudget: true,
+          defaultEffort: 'medium',
+        }
+      : {
+          transport: 'openai-compatible',
+          control: this.modelCapabilities.acceptsThinkingKwarg
+            ? 'enable-thinking'
+            : 'no-control',
+        };
+    const reasoning = reasoningWireFragment(resolveReasoningPlan({
+      enabled: thinkingEnabled,
+      budgetTokens: options.reasoningBudget,
+      effort: 'medium',
+    }, reasoningMetadata));
     return {
       model: this.config.modelId,
       messages: openaiMessages,
@@ -108,7 +131,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
       // servers that advertised (at discovery) that they honor it. Gating on a
       // discovered capability — not the endpoint's port — keeps the "which server
       // accepts this?" decision in one place and free of implementation coupling.
-      ...(this.modelCapabilities.acceptsThinkingKwarg && { chat_template_kwargs: { enable_thinking: thinkingEnabled } }),
+      ...reasoning,
     };
   }
 

--- a/src/services/providers/openAICompatibleStream.ts
+++ b/src/services/providers/openAICompatibleStream.ts
@@ -12,6 +12,7 @@ import type {
   OpenAIStreamState,
   OllamaChatRequest,
 } from './openAICompatibleTypes';
+import { reasoningWireFragment, resolveReasoningPlan } from '@offgrid/models';
 
 /**
  * Streaming parser for <think>...</think> tags embedded in delta.content.
@@ -315,8 +316,16 @@ export async function generateOllamaChatImpl(
     };
   });
 
+  const reasoning = reasoningWireFragment(resolveReasoningPlan({
+    enabled: thinkingEnabled,
+    budgetTokens: options.reasoningBudget,
+    effort: 'medium',
+  }, {
+    transport: 'ollama',
+    control: 'boolean',
+  }));
   const requestBody: Record<string, unknown> = {
-    model: modelId, messages: ollamaMessages, stream: true, think: thinkingEnabled,
+    model: modelId, messages: ollamaMessages, stream: true, ...reasoning,
     ...(options.tools && options.tools.length > 0 && { tools: options.tools }),
     options: {
       ...(options.temperature !== undefined && { temperature: options.temperature }),

--- a/src/services/providers/types.ts
+++ b/src/services/providers/types.ts
@@ -76,6 +76,8 @@ export interface GenerationOptions {
   stopSequences?: string[];
   /** Whether to enable thinking/reasoning mode (Ollama: sends "think" param; others: parsed from response) */
   enableThinking?: boolean;
+  /** Optional provider-neutral reasoning budget in tokens. */
+  reasoningBudget?: number;
 }
 
 /** Tool definition for function calling */
@@ -163,4 +165,3 @@ export interface LLMProvider {
   /** Clean up resources */
   dispose?(): Promise<void>;
 }
-

--- a/src/services/remoteMediaRuntime.ts
+++ b/src/services/remoteMediaRuntime.ts
@@ -2,8 +2,6 @@ import { remoteServerManager } from './remoteServerManager';
 import type { RemoteMediaModelIds, RemoteServer } from '../types';
 import { REMOTE_FETCH_REDIRECT_POLICY, remoteAuthorizationHeaders } from './remoteTransportPolicy';
 
-const REQUEST_TIMEOUT_MS = 60_000;
-
 export interface RemoteImageResult {
   base64?: string;
   url?: string;
@@ -37,7 +35,6 @@ async function request<T>(
   const controller = new AbortController();
   const abort = () => controller.abort();
   signal?.addEventListener('abort', abort, { once: true });
-  const timeout = setTimeout(abort, REQUEST_TIMEOUT_MS);
   try {
     const apiKey = await remoteServerManager.getApiKey(server.id);
     if (controller.signal.aborted) throw new Error('Remote request cancelled');
@@ -55,14 +52,13 @@ async function request<T>(
       const detail = await response.text().catch(() => '');
       throw new Error(detail || `Remote server returned HTTP ${response.status}`);
     }
-    // Keep timeout and caller cancellation attached until the response body is
-    // consumed. A successful header is not a completed image/audio transfer.
+    // Keep caller cancellation attached until the response body is consumed.
+    // A successful header is not a completed image/audio transfer.
     return await consume(response);
   } catch (error) {
     if (controller.signal.aborted) throw new Error('Remote request cancelled');
     throw error;
   } finally {
-    clearTimeout(timeout);
     signal?.removeEventListener('abort', abort);
   }
 }

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,9 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { Message, Conversation, GenerationMeta } from '../types';
-import {
-  stripStreamingControlTokens,
-} from '../utils/messageContent';
+import { stripStreamingControlTokens } from '../utils/messageContent';
 import { generateId } from '../utils/generateId';
 import { createHydrationGatedStorage } from '../utils/hydrationGatedStorage';
 import {
@@ -164,7 +162,6 @@ const MODEL_NOT_LOADING = {
   loadingModelName: null,
 };
 const NO_REPLY_ENDED = { lastReplyEnd: null };
-
 const NO_REPLY_FORMING: StreamingFields = {
   streamingMessage: '',
   streamingReasoningContent: '',
@@ -173,9 +170,9 @@ const NO_REPLY_FORMING: StreamingFields = {
   isStreaming: false,
   isThinking: false,
 };
-
-const chatStorage = createHydrationGatedStorage<PersistedChatState>();
-
+const chatStorage = createHydrationGatedStorage<PersistedChatState>(undefined, (previous, next) =>
+  previous.conversations === next.conversations &&
+  previous.activeConversationId === next.activeConversationId);
 export const useChatStore = create<ChatState>()(
   persist(
     (set, get) => ({
@@ -398,7 +395,10 @@ export const useChatStore = create<ChatState>()(
         // End the ephemeral reply before the durable mutation leaves this device. Both use the same
         // peer link. This order guarantees a receiver sees the final stream frame first and then the
         // record that replaces it, never the reverse order that could recreate a retired preview.
-        set({ ...NO_REPLY_FORMING, lastReplyEnd: { conversationId, persisted } });
+        set({
+          ...NO_REPLY_FORMING,
+          lastReplyEnd: { conversationId, persisted },
+        });
         if (persisted) {
           addMessage(conversationId, {
             role: 'assistant',

--- a/src/utils/hydrationGatedStorage.ts
+++ b/src/utils/hydrationGatedStorage.ts
@@ -14,17 +14,38 @@ export interface HydrationGatedStorage<S> {
 /** Prevent boot-time defaults from replacing saved state before Zustand finishes hydration. */
 export function createHydrationGatedStorage<S>(
   base: StateStorage = AsyncStorage,
+  unchanged?: (previous: S, next: S) => boolean,
 ): HydrationGatedStorage<S> {
   let hydrated = false;
+  let lastWritten: S | undefined;
   const json = createJSONStorage<S>(() => base);
   if (!json) throw new Error('JSON storage is unavailable');
 
   return {
     storage: {
-      getItem: name => json.getItem(name),
-      setItem: (name, value) =>
-        hydrated ? json.setItem(name, value) : undefined,
-      removeItem: name => (hydrated ? json.removeItem(name) : undefined),
+      getItem: async name => {
+        const value = await json.getItem(name);
+        lastWritten = value?.state;
+        return value;
+      },
+      setItem: (name, value) => {
+        if (!hydrated) return undefined;
+        if (lastWritten !== undefined && unchanged?.(lastWritten, value.state))
+          return undefined;
+        const previous = lastWritten;
+        lastWritten = value.state;
+        const write = json.setItem(name, value);
+        if (!(write instanceof Promise)) return write;
+        return write.catch(error => {
+          if (lastWritten === value.state) lastWritten = previous;
+          throw error;
+        });
+      },
+      removeItem: name => {
+        if (!hydrated) return undefined;
+        lastWritten = undefined;
+        return json.removeItem(name);
+      },
     },
     markHydrated: () => {
       hydrated = true;


### PR DESCRIPTION
## Summary

- Compact the exact active prompt, including committed tool rounds and visible partial text.
- Continue slow work until explicit cancellation.
- Reset failed fallback output, show the route change, and store the model that answered.
- Let a memory-refused active turn retry explicitly without a duplicate assistant message.
- Keep edit focus while the sheet is open.
- Limit persistence, Home, project, message-row, and Pro sync work during token streaming.
- Make the pre-push hook the documented local quality gate.

## Release flows

CHAT-01 through CHAT-05 for Mobile.

## Dependencies

- Shared: https://github.com/off-grid-ai/shared/pull/24
- Mobile Pro: https://github.com/off-grid-ai/mobile-pro/pull/67

## Verification

- Mobile push passed, but its new-branch change detector produced no gate output. This detector needs a separate fix.
- Focused Mobile tests: 216 passed.
- Mobile Pro pre-push: lint, typecheck, 121 suites passed, 274 tests passed, and 1 test skipped.

Live visual verification is still required.