### PR TITLE
Recover chat turns and reduce transient updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
   pull_request:
     branches:
       - main
+      - 'release/**'
 
 # ONE job, not four.
 #

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -83,6 +83,11 @@ ${file}"
 __tests__/unit/services/generationService.test.ts
 __tests__/integration/generation/errorKeepsPartial.rendered.redflow.test.tsx"
         ;;
+      src/services/llmHelpers.ts)
+        MAPPED_TESTS="${MAPPED_TESTS}
+__tests__/unit/services/llmHelpers.test.ts
+__tests__/unit/services/llmHelpers.branches.test.ts"
+        ;;
       *)
         RELATED_JS="${RELATED_JS}
 ${file}"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -66,7 +66,41 @@ if [ -n "$PUSHED_JS" ]; then
   echo "▶ JS/TS tests (related to changed files)..."
   # Keep related rendered journeys serial because they share native-boundary state.
   # Do not force the process to exit: leaked asynchronous work is a test failure to fix.
-  echo "$PUSHED_JS" | tr '\n' '\0' | xargs -0 npx jest --findRelatedTests --passWithNoTests --runInBand --bail=1
+  DIRECT_TESTS=""
+  MAPPED_TESTS=""
+  RELATED_JS=""
+  while IFS= read -r file; do
+    case "$file" in
+      __tests__/*|*/__tests__/*|*.test.ts|*.test.tsx|*.test.js|*.test.jsx)
+        DIRECT_TESTS="${DIRECT_TESTS}
+${file}"
+        ;;
+      src/services/generationRemoteHelpers.ts)
+        # This helper is imported through the central generation barrel. Jest's
+        # unrestricted reverse graph reaches most screens through the navigator,
+        # although those screens cannot execute this remote-generation contract.
+        MAPPED_TESTS="${MAPPED_TESTS}
+__tests__/unit/services/generationService.test.ts
+__tests__/integration/generation/errorKeepsPartial.rendered.redflow.test.tsx"
+        ;;
+      *)
+        RELATED_JS="${RELATED_JS}
+${file}"
+        ;;
+    esac
+  done <<EOF
+$PUSHED_JS
+EOF
+  SELECTED_TESTS=$(printf '%s\n%s\n' "$DIRECT_TESTS" "$MAPPED_TESTS" | sed '/^$/d' | sort -u)
+  if [ -n "$SELECTED_TESTS" ]; then
+    printf '%s\n' "$SELECTED_TESTS" | tr '\n' '\0' | \
+      xargs -0 npx jest --passWithNoTests --runInBand --bail=1
+  fi
+  RELATED_JS=$(printf '%s\n' "$RELATED_JS" | sed '/^$/d' | sort -u)
+  if [ -n "$RELATED_JS" ]; then
+    printf '%s\n' "$RELATED_JS" | tr '\n' '\0' | \
+      xargs -0 npx jest --findRelatedTests --passWithNoTests --runInBand --bail=1
+  fi
 
   echo "▶ Architecture gate (dependency-cruiser)..."
   npm run depcruise

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,6 +2,18 @@
 
 ZERO_OID="0000000000000000000000000000000000000000"
 
+new_branch_base() {
+  local_oid=$1
+  for candidate in "${OFFGRID_PUSH_BASE:-}" origin/release/computer_use origin/main; do
+    [ -z "$candidate" ] && continue
+    if git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+      git merge-base "$local_oid" "$candidate"
+      return
+    fi
+  done
+  git rev-list --max-parents=0 "$local_oid" | tail -1
+}
+
 collect_changed_files() {
   changed_files=""
 
@@ -15,14 +27,11 @@ collect_changed_files() {
     [ "$local_oid" = "$ZERO_OID" ] && continue
 
     if [ "$remote_oid" = "$ZERO_OID" ]; then
-      # A new branch has no remote tip. Inspect only commits that are not already
-      # reachable from origin instead of assuming the branch started from main.
-      commits=$(git rev-list "$local_oid" --not --remotes=origin 2>/dev/null || true)
-      if [ -n "$commits" ]; then
-        changed=$(git diff-tree --no-commit-id --name-only -r --diff-filter=ACMR $commits)
-      else
-        changed=""
-      fi
+      # A new branch has no remote tip. Diff its complete range from the release
+      # base. Passing several commits to diff-tree can silently compare trees and
+      # omit earlier commits in the push.
+      base=$(new_branch_base "$local_oid")
+      changed=$(git diff --name-only --diff-filter=ACMR "$base..$local_oid")
     else
       range="$remote_oid..$local_oid"
       changed=$(git diff --name-only --diff-filter=ACMR "$range")

--- a/rules.md
+++ b/rules.md
@@ -276,19 +276,19 @@ When the user says "push" (or any equivalent like "ship it", "send it", "push th
 
 ### Before pushing
 0. Write tests for any new or changed logic if they don't already exist.
-1. Run `npm run lint && npx tsc --noEmit && npm test` - fix any failures before continuing.
-2. Commit all staged changes with a descriptive message.
-3. Ensure you are NOT on `main`. If you are, create an appropriately named branch first: `git checkout -b feat/...` or `fix/...` or `chore/...` etc.
+1. Commit all staged changes with a descriptive message.
+2. Ensure you are NOT on `main`. If you are, create an appropriately named branch first: `git checkout -b feat/...` or `fix/...` or `chore/...` etc.
 
 ### Pushing & PR
-4. Push the branch: `git push -u origin <branch>`
+3. Push the branch normally: `git push -u origin <branch>`. The pre-push hook is the required local quality gate and owns lint, typecheck, and the applicable test suite. Never bypass it with `--no-verify`.
+4. If the pre-push hook fails, fix the reported failure, commit the fix, and push again. Run a full lint, typecheck, or test command separately only when it is needed to diagnose that hook failure.
 5. If no PR exists for this branch, create one with `gh pr create`. **Do NOT include "Generated with Codex" or any AI attribution in PR descriptions.**
 6. If a PR already exists, update its description to reflect **all commits in the PR** (not just the latest push). Read the full commit history with `git log main..HEAD` and write a coherent description that summarises the entire change set - what it does, why, and how.
 
 ### Review loop
 7. Wait for Gemini to review the PR (poll with `gh pr checks` and `gh api repos/{owner}/{repo}/pulls/{number}/reviews` until a review appears).
 8. Pull down review comments: `gh api repos/{owner}/{repo}/pulls/{number}/comments` and `gh api repos/{owner}/{repo}/pulls/{number}/reviews`.
-9. Address every review comment - fix the code, re-run quality gates (lint, tsc, test).
+9. Address every review comment - fix the code, commit it, and let the next normal push run the pre-push quality gate.
 10. Reply to **each** review comment individually using `gh api` (`/pulls/comments/{id}/replies`). Every comment gets its own reply - do not post a single summary comment.
 11. Push fixes, update the PR description again to stay coherent across all commits.
 12. Report what was changed in response to the review.
@@ -307,7 +307,7 @@ The repo has three automated reviewers on every PR. After pushing, loop until al
 1. Push code → wait for all three reviewers to report
 2. Pull down Gemini comments, Codecov report, and SonarCloud findings
 3. Fix issues: code changes for Gemini/SonarCloud, add tests for Codecov
-4. Re-run local quality gates (`npm run lint && npm test && npx tsc --noEmit`)
+4. Commit the fixes and push normally. The pre-push hook runs the local quality gates.
 5. Push fixes, comment `/gemini review` on the PR to re-trigger Gemini
 6. Repeat until all three reviewers pass with no blocking issues
 

--- a/src/components/AppSheet.tsx
+++ b/src/components/AppSheet.tsx
@@ -215,6 +215,8 @@ export const AppSheet: React.FC<AppSheetProps> = ({
 
   useEffect(() => {
     if (visible) {
+      // The sheet is already open. Do not dismiss an input that just took focus.
+      if (modalVisible) return;
       pendingAnimateIn.current = true;
       // Dismiss keyboard first, then open — prevents animation conflict
       const keyboardVisible = Keyboard.isVisible?.() ?? false;
@@ -247,7 +249,7 @@ export const AppSheet: React.FC<AppSheetProps> = ({
         onClosedRef.current?.();
       });
     }
-  }, [visible]);
+  }, [animateOut, modalVisible, visible]);
 
   // Track keyboard height so the sheet lifts above the keyboard
   useEffect(() => {

--- a/src/components/ChatInput/Popovers.tsx
+++ b/src/components/ChatInput/Popovers.tsx
@@ -117,7 +117,11 @@ export const QuickSettingsPopover: React.FC<QuickSettingsPopoverProps> = ({
   mcpToolCount = 0, onMcpPress,
 }) => {
   const { colors } = useTheme();
-  const { settings, updateSettings, toolCountHintDismissed } = useAppStore();
+  const thinkingEnabled = useAppStore(state => state.settings.thinkingEnabled);
+  const updateSettings = useAppStore(state => state.updateSettings);
+  const toolCountHintDismissed = useAppStore(
+    state => state.toolCountHintDismissed,
+  );
 
   if (!visible) return null;
 
@@ -177,16 +181,16 @@ export const QuickSettingsPopover: React.FC<QuickSettingsPopoverProps> = ({
                   style={popoverStyles.row}
                   onPress={() => {
                     triggerHaptic('impactLight');
-                    updateSettings({ thinkingEnabled: !settings.thinkingEnabled });
+                    updateSettings({ thinkingEnabled: !thinkingEnabled });
                   }}
                 >
-                  <Icon name="zap" size={16} color={settings.thinkingEnabled ? colors.primary : colors.textMuted} />
+                  <Icon name="zap" size={16} color={thinkingEnabled ? colors.primary : colors.textMuted} />
                   <Text style={[popoverStyles.rowLabel, { color: colors.text }]}>Thinking</Text>
                   <View style={[popoverStyles.badge, {
-                    backgroundColor: settings.thinkingEnabled ? colors.primary : colors.textMuted,
+                    backgroundColor: thinkingEnabled ? colors.primary : colors.textMuted,
                   }]}>
                     <Text style={[popoverStyles.badgeText, { color: colors.background }]}>
-                      {settings.thinkingEnabled ? 'ON' : 'OFF'}
+                      {thinkingEnabled ? 'ON' : 'OFF'}
                     </Text>
                   </View>
                 </TouchableOpacity>

--- a/src/components/ChatInput/Voice.ts
+++ b/src/components/ChatInput/Voice.ts
@@ -83,7 +83,8 @@ export function useVoiceInput({ conversationId, interfaceMode, onTranscript, onA
   onAudioAttachmentRef.current = onAudioAttachment;
   const onAutoSendRef = useRef(onAutoSend);
   onAutoSendRef.current = onAutoSend;
-  const { downloadedModelId, transcriptionLanguage } = useWhisperStore();
+  const downloadedModelId = useWhisperStore(state => state.downloadedModelId);
+  const transcriptionLanguage = useWhisperStore(state => state.transcriptionLanguage);
   const remoteTranscriptionAvailable = useRemoteTranscriptionAvailable();
   const [isDirectRecording, setIsDirectRecording] = useState(false);
   const [isAudioModeRecording, setIsAudioModeRecording] = useState(false);

--- a/src/components/ChatInput/index.tsx
+++ b/src/components/ChatInput/index.tsx
@@ -216,8 +216,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     isStartingRecording ||
     isTranscribing;
 
-  const { settings: appSettings, updateSettings: updateAppSettings } = useAppStore();
-  const thinkingEnabled = appSettings.thinkingEnabled;
+  const thinkingEnabled = useAppStore(state => state.settings.thinkingEnabled);
+  const updateAppSettings = useAppStore(state => state.updateSettings);
 
   const handleThinkingToggle = () => {
     triggerHaptic('impactLight');

--- a/src/components/ChatMessage/components/ToolMessages.tsx
+++ b/src/components/ChatMessage/components/ToolMessages.tsx
@@ -31,6 +31,10 @@ function getToolIcon(toolName?: string): string {
       return 'clock';
     case 'get_device_info':
       return 'smartphone';
+    case 'context_compaction':
+      return 'archive';
+    case 'model_fallback':
+      return 'shuffle';
     default:
       return 'tool';
   }
@@ -55,6 +59,10 @@ function getToolLabel(toolName?: string, content?: string): string {
       return 'Web Use';
     case 'computer_use':
       return 'Computer Use';
+    case 'context_compaction':
+      return 'Context compacted';
+    case 'model_fallback':
+      return 'Model changed';
     default:
       return toolName || 'Tool result';
   }

--- a/src/components/GenerationSettingsModal/TextGenerationSection.tsx
+++ b/src/components/GenerationSettingsModal/TextGenerationSection.tsx
@@ -31,7 +31,7 @@ export const TextGenerationSection: React.FC = () => {
   const { isLiteRT, llama, liteRT, toolCalls } = useTextGenerationSettings();
   const basicSettings = isLiteRT
     ? [liteRT.temperature, liteRT.maxTokens]
-    : [llama.temperature, llama.maxTokens, llama.contextLength];
+    : [llama.temperature, llama.contextLength, llama.maxTokens];
   const advancedSettings = isLiteRT
     ? [liteRT.topP, toolCalls]
     : [llama.topP, llama.repeatPenalty, toolCalls];

--- a/src/components/ModelFailureCard.tsx
+++ b/src/components/ModelFailureCard.tsx
@@ -73,7 +73,7 @@ function FailureRow({ failure, onDismiss }: { failure: ModelFailure; onDismiss: 
             <ActionButton
               icon="zap"
               color={colors.error}
-              label="Load Anyway"
+              label="Run anyway"
               testID={`model-failure-load-anyway-${failure.modelType}`}
               onPress={() => { onDismiss(); failure.onLoadAnyway?.(); }}
               styles={styles}

--- a/src/components/settings/textGenAdvancedSections.tsx
+++ b/src/components/settings/textGenAdvancedSections.tsx
@@ -203,30 +203,33 @@ export const ModelLoadingModeSelector: React.FC = () => {
 
 // ─── Thinking Budget ─────────────────────────────────────────────────────────
 
-// Values AND labels come from the shared @offgrid/models contract so OGAD and OGAM render
-// identical options. Only the "tokens" suffix is trimmed: six pills share one row here, so the
-// pill shows the number ("512", "2K") and the description carries the unit.
-const THINKING_BUDGET_OPTIONS: PillOption<string>[] = [
-  { id: String(REASONING_BUDGET_AUTO), label: 'Auto' },
-  ...REASONING_BUDGET_OPTIONS.map(v => ({
-    id: String(v),
-    label: reasoningBudgetLabel(v).replace(' tokens', ''),
-  })),
-];
+const THINKING_BUDGET_VALUES = [
+  REASONING_BUDGET_AUTO,
+  ...REASONING_BUDGET_OPTIONS,
+] as const;
 
 /** llama.rn path only: the cap rides the completion request as thinking_budget_tokens
  *  (shared rule: @offgrid/models thinkingBudgetPayload). LiteRT has no thinking channel. */
 export const ThinkingBudgetSelector: React.FC = () => {
   const { settings, updateSettings } = useAppStore();
-  const current = String(settings.reasoningBudget ?? REASONING_BUDGET_AUTO);
+  const current = settings.reasoningBudget ?? REASONING_BUDGET_AUTO;
+  const selectedIndex = THINKING_BUDGET_VALUES.findIndex(
+    value => value === current,
+  );
+  const currentIndex = selectedIndex < 0 ? 0 : selectedIndex;
   return (
-    <SegmentedRow<string>
-      label="Thinking Budget"
+    <SliderSetting
+      testID="thinking-budget"
+      label="Thinking"
       description="Auto lets the model think for as long as it needs. A cap ends the thinking at that many tokens so the answer arrives sooner. Applies when Thinking is on."
-      options={THINKING_BUDGET_OPTIONS}
-      current={current}
-      onSelect={(id) => updateSettings({ reasoningBudget: Number(id) })}
-      testIdFor={(id) => `thinking-budget-${id}-button`}
+      value={currentIndex}
+      min={0}
+      max={THINKING_BUDGET_VALUES.length - 1}
+      step={1}
+      formatValue={(index) => reasoningBudgetLabel(THINKING_BUDGET_VALUES[Math.round(index)]!)}
+      onChange={(index) =>
+        updateSettings({ reasoningBudget: THINKING_BUDGET_VALUES[Math.round(index)]! })
+      }
     />
   );
 };

--- a/src/hooks/useTextGenerationSettings.ts
+++ b/src/hooks/useTextGenerationSettings.ts
@@ -113,7 +113,7 @@ export function useTextGenerationSettings() {
     },
     contextLength: {
       key: 'contextLength',
-      label: 'Context Length',
+      label: 'Context Window',
       description: 'KV cache size - larger uses more RAM (requires reload)',
       value: contextLength,
       min: 512,

--- a/src/screens/ChatScreen/ChatMessageArea.tsx
+++ b/src/screens/ChatScreen/ChatMessageArea.tsx
@@ -3,7 +3,6 @@ import {
   View,
   FlatList,
   Text,
-  Keyboard,
   Platform,
 } from 'react-native';
 import { useUiModeStore } from '../../stores/uiModeStore';
@@ -158,7 +157,7 @@ export const ChatMessageArea: React.FC<ChatMessageAreaProps> = ({
   const hasScrolledRef = React.useRef(false);
   const interfaceMode = useUiModeStore(s => s.interfaceMode);
   const tabNav = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-  const { toolCountHintDismissed } = useAppStore();
+  const toolCountHintDismissed = useAppStore(s => s.toolCountHintDismissed);
   // Subscribe to Pro activation so this re-renders the moment a license is
   // activated. loadProFeatures() registers the tool extensions + the Pro Tools
   // screen in one pass; without this subscription the getToolExtensions() reads
@@ -273,7 +272,6 @@ export const ChatMessageArea: React.FC<ChatMessageAreaProps> = ({
           scrollEventThrottle={16}
           keyboardDismissMode="on-drag"
           keyboardShouldPersistTaps="handled"
-          onTouchStart={() => Keyboard.dismiss()}
           maintainVisibleContentPosition={{
             minIndexForVisible: 0,
             autoscrollToTopThreshold: 100,

--- a/src/screens/ChatScreen/MessageRenderer.tsx
+++ b/src/screens/ChatScreen/MessageRenderer.tsx
@@ -8,6 +8,8 @@ import { Message } from '../../types';
 import { useUiModeStore } from '../../stores';
 import { getSlot, SLOTS } from '../../bootstrap/slotRegistry';
 import { ChatMessageItem } from './useChatScreen';
+import { STREAMING_MESSAGE_ID } from './types';
+import { useActiveStreamText } from './useActiveStreamText';
 
 type MessageRendererProps = {
   item: Message | ChatMessageItem;
@@ -160,7 +162,32 @@ export function messageRendererPropsEqual(
   );
 }
 
-export const MessageRenderer = React.memo(
+const CommittedMessageRenderer = React.memo(
   MessageRendererInner,
+  messageRendererPropsEqual,
+);
+
+const LiveStreamMessageRenderer: React.FC<MessageRendererProps> = props => {
+  const live = useActiveStreamText();
+  const item = React.useMemo(
+    () => ({
+      ...props.item,
+      content: live.content,
+      reasoningContent: live.reasoningContent,
+    }),
+    [props.item, live],
+  );
+  return <CommittedMessageRenderer {...props} item={item} />;
+};
+
+const MessageRendererDispatch: React.FC<MessageRendererProps> = props =>
+  props.item.id === STREAMING_MESSAGE_ID ? (
+    <LiveStreamMessageRenderer {...props} />
+  ) : (
+    <CommittedMessageRenderer {...props} />
+  );
+
+export const MessageRenderer = React.memo(
+  MessageRendererDispatch,
   messageRendererPropsEqual,
 );

--- a/src/screens/ChatScreen/types.ts
+++ b/src/screens/ChatScreen/types.ts
@@ -107,10 +107,13 @@ function groupSupportingContextWithImage(
  */
 export type RemoteStreamItem = ChatStreamPreviewRow;
 
+export const STREAMING_MESSAGE_ID = 'streaming';
+
 export type StreamingState = {
   isThinking: boolean;
   streamingMessage: string;
   streamingReasoningContent: string;
+  hasStreamingText?: boolean;
   isStreamingForThisConversation: boolean;
   isModelLoading?: boolean;
   loadingModelName?: string;
@@ -268,7 +271,7 @@ function localDisplayMessages(
     ];
   }
   if (
-    (streamingMessage || streamingReasoningContent) &&
+    (streamingMessage || streamingReasoningContent || streaming.hasStreamingText) &&
     isStreamingForThisConversation
   ) {
     if (_lastDisplayBranch !== 'streaming') {
@@ -277,7 +280,7 @@ function localDisplayMessages(
     return [
       ...allMessages,
       {
-        id: 'streaming',
+        id: STREAMING_MESSAGE_ID,
         role: 'assistant' as const,
         content: streamingMessage,
         reasoningContent: streamingReasoningContent || undefined,

--- a/src/screens/ChatScreen/useActiveStreamText.ts
+++ b/src/screens/ChatScreen/useActiveStreamText.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { useChatStore } from '../../stores';
+
+export function useActiveStreamText(): {
+  content: string;
+  reasoningContent?: string;
+} {
+  const content = useChatStore(state => state.streamingMessage);
+  const reasoning = useChatStore(state => state.streamingReasoningContent);
+  return useMemo(
+    () => ({ content, reasoningContent: reasoning || undefined }),
+    [content, reasoning],
+  );
+}
+
+export function useHasActiveStreamText(): boolean {
+  return useChatStore(
+    state =>
+      state.streamingMessage.length > 0 ||
+      state.streamingReasoningContent.length > 0,
+  );
+}

--- a/src/screens/ChatScreen/useChatGenerationActions.ts
+++ b/src/screens/ChatScreen/useChatGenerationActions.ts
@@ -518,17 +518,29 @@ async function generateWithCompactionRetry(
       .getState()
       .conversations.find(c => c.id === opts.id);
     const previousSummary = conversation?.compactionSummary;
+    const activeTurnStartMessageId = [...opts.messages]
+      .reverse()
+      .find(message => message.role === 'user')?.id;
+    const currentMessages = conversation?.messages?.length
+      ? conversation.messages
+      : opts.messages;
+    const beforeCount = currentMessages.filter(message => message.role !== 'system').length;
     const compacted = await contextCompactionService
       .compact({
         conversationId: opts.id,
         systemPrompt: opts.prompt,
-        allMessages: opts.messages,
+        allMessages: currentMessages,
         previousSummary,
+        activeTurnStartMessageId,
       })
       .catch(async () => {
         await llmService.clearKVCache(true).catch(() => {});
-        const recent = opts.messages
-          .filter(m => m.role !== 'system')
+        const nonSystem = currentMessages.filter(m => m.role !== 'system');
+        const activeStart = activeTurnStartMessageId
+          ? nonSystem.findIndex(message => message.id === activeTurnStartMessageId)
+          : -1;
+        const activeTurn = activeStart >= 0 ? nonSystem.slice(activeStart) : [];
+        const recentHistory = (activeStart >= 0 ? nonSystem.slice(0, activeStart) : nonSystem)
           .slice(-FALLBACK_RECENT_MESSAGE_COUNT);
         return [
           {
@@ -537,9 +549,17 @@ async function generateWithCompactionRetry(
             content: opts.prompt,
             timestamp: 0,
           } as Message,
-          ...recent,
+          ...recentHistory,
+          ...activeTurn,
         ];
       });
+    const afterCount = compacted.filter(message => message.role !== 'system').length;
+    if (afterCount >= beforeCount) throw error;
+    useChatStore.getState().addMessage(opts.id, {
+      role: 'assistant',
+      content: `Context compacted: ${beforeCount} → ${afterCount} messages`,
+      isSystemInfo: true,
+    });
     // Stop/Eject can arrive while the summary is running. Do not start a new
     // completion after the owner has cancelled this turn.
     if (generationService.wasAborted()) return true;

--- a/src/screens/ChatScreen/useChatModelActions.ts
+++ b/src/screens/ChatScreen/useChatModelActions.ts
@@ -2,7 +2,6 @@ import { Dispatch, SetStateAction, useEffect } from 'react';
 import {
   AlertState,
   showAlert,
-  hideAlert,
 } from '../../components';
 import { llmService, activeModelService, modelManager, generationService } from '../../services';
 import { isModelReady, activeLocalTextCapabilities, activeTextCapabilities, backendFallbackNotice } from '../../services/engines';
@@ -12,6 +11,10 @@ import logger from '../../utils/logger';
 import { ModelReadyOutcome, reasonFromLoadError } from './modelReadiness';
 import { isOverridableMemoryError } from '../../services/modelLoadErrors';
 import { loadModelWithOverride } from '../../services/loadModelWithOverride';
+import {
+  clearModelFailure,
+  reportModelFailure,
+} from '../../services/modelFailureHandler';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
 
@@ -84,26 +87,6 @@ function addBackendFallbackMsg(deps: Pick<ModelActionDeps, 'activeModel' | 'acti
   });
 }
 
-async function doLoadTextModel(deps: ModelActionDeps, opts?: { override?: boolean }): Promise<void> {
-  const { activeModel, activeModelId } = deps;
-  if (!activeModel || !activeModelId) return;
-  try {
-    await activeModelService.loadTextModel(activeModelId, undefined, opts);
-    deps.setSupportsVision(loadedModelVision(activeModel));
-    if (deps.modelLoadStartTimeRef.current && deps.settings.showGenerationDetails) {
-      const loadTime = ((Date.now() - deps.modelLoadStartTimeRef.current) / 1000).toFixed(1);
-      addSystemMsg(deps, `Model loaded: ${activeModel.name} (${loadTime}s)`);
-    }
-    addBackendFallbackMsg(deps);
-  } catch (error: any) {
-    deps.setAlertState(showAlert('Error', `Failed to load model: ${error?.message || 'Unknown error'}`));
-  } finally {
-    deps.setIsModelLoading(false);
-    deps.setLoadingModel(null);
-    deps.modelLoadStartTimeRef.current = null;
-  }
-}
-
 export async function initiateModelLoad(
   deps: ModelActionDeps,
   alreadyLoading: boolean,
@@ -148,27 +131,33 @@ export async function initiateModelLoad(
       // That is overridable — offer "Load Anyway" (force the load) rather than a
       // dead-end "Failed to load model" the user can only dismiss.
       if (isOverridableMemoryError(error)) {
-        deps.setAlertState(showAlert(
-          'Insufficient Memory',
-          `${detail}\n\nWould you like to override these safeguards and load it anyway?`,
-          [
-            { text: 'Cancel', style: 'cancel' },
-            {
-              text: 'Load Anyway', style: 'destructive', onPress: () => {
-                deps.setAlertState(hideAlert());
-                deps.setIsModelLoading(true);
-                deps.setLoadingModel(activeModel);
-                deps.modelLoadStartTimeRef.current = Date.now();
-                waitForRenderFrame()
-                  .then(() => doLoadTextModel(deps, { override: true }))
-                  // Resume once the load resolves — don't gate on isModelLoaded() (races
-                  // false after a multimodal load, dropping the resume). See the sibling path.
-                  .then(() => onLoadedResume?.())
-                  .catch((e) => logger.error('[ModelLoad] Load Anyway resume failed:', e));
-              },
-            },
-          ],
-        ));
+        reportModelFailure('text', error, {
+          id: 'chat-text-load',
+          onLoadAnyway: () => {
+            deps.setIsModelLoading(true);
+            deps.setLoadingModel(activeModel);
+            deps.modelLoadStartTimeRef.current = Date.now();
+            void waitForRenderFrame()
+              .then(() =>
+                activeModelService.loadTextModel(activeModelId, undefined, {
+                  override: true,
+                }),
+              )
+              .then(() => {
+                deps.setSupportsVision(loadedModelVision(activeModel));
+                clearModelFailure('text');
+                onLoadedResume?.();
+              })
+              .catch(cause =>
+                reportModelFailure('text', cause, { id: 'chat-text-load' }),
+              )
+              .finally(() => {
+                deps.setIsModelLoading(false);
+                deps.setLoadingModel(null);
+                deps.modelLoadStartTimeRef.current = null;
+              });
+          },
+        });
         return { ok: false, reason: 'insufficient-memory', detail, alerted: true };
       }
       deps.setAlertState(showAlert('Error', `Failed to load model: ${detail}`));

--- a/src/screens/ChatScreen/useChatScreen.ts
+++ b/src/screens/ChatScreen/useChatScreen.ts
@@ -14,6 +14,7 @@ import {
 } from '../../stores';
 import { useSyncIdentityStore } from '../../stores/syncIdentityStore';
 import { useRemoteChatStreamPreviews } from './useRemoteChatStreamPreviews';
+import { useHasActiveStreamText } from './useActiveStreamText';
 import { useActiveTextModel } from '../../hooks/useActiveTextModel';
 import { hardwareService } from '../../services';
 import { useGeneratingConversationId } from '../../hooks/useGenerationSession';
@@ -54,6 +55,7 @@ export { computePendingSettings } from './pendingSettings';
 
 type ChatScreenRouteProp = RouteProp<RootStackParamList, 'Chat'>;
 
+// eslint-disable-next-line max-lines-per-function -- one screen-model hook coordinates existing chat owners
 export const useChatScreen = () => {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const route = useRoute<ChatScreenRouteProp>();
@@ -103,19 +105,17 @@ export const useChatScreen = () => {
   const { imageGenState, isCompacting, queueCount, queuedTexts } =
     useChatRuntimeSubscriptions(genDepsRef, startGenerationRef);
 
-  const {
-    activeModelId,
-    downloadedModels,
-    settings,
-    activeImageModelId,
-    downloadedImageModels,
-    setDownloadedImageModels,
-    setIsGeneratingImage: setAppIsGeneratingImage,
-    setImageGenerationStatus: setAppImageGenerationStatus,
-    removeImagesByConversationId,
-    loadedSettings,
-    textModelEvicted,
-  } = useAppStore();
+  const activeModelId = useAppStore(s => s.activeModelId);
+  const downloadedModels = useAppStore(s => s.downloadedModels);
+  const settings = useAppStore(s => s.settings);
+  const activeImageModelId = useAppStore(s => s.activeImageModelId);
+  const downloadedImageModels = useAppStore(s => s.downloadedImageModels);
+  const setDownloadedImageModels = useAppStore(s => s.setDownloadedImageModels);
+  const setAppIsGeneratingImage = useAppStore(s => s.setIsGeneratingImage);
+  const setAppImageGenerationStatus = useAppStore(s => s.setImageGenerationStatus);
+  const removeImagesByConversationId = useAppStore(s => s.removeImagesByConversationId);
+  const loadedSettings = useAppStore(s => s.loadedSettings);
+  const textModelEvicted = useAppStore(s => s.textModelEvicted);
 
   // Remote model state - use proper selectors for reactivity
   const activeServerId = useRemoteServerStore(s => s.activeServerId);
@@ -124,30 +124,26 @@ export const useChatScreen = () => {
   );
   const discoveredModels = useRemoteServerStore(s => s.discoveredModels);
 
-  const {
-    activeConversationId,
-    conversations,
-    createConversation,
-    addMessage,
-    updateMessageContent,
-    updateMessageTurnKind,
-    deleteMessagesAfter,
-    streamingMessage,
-    streamingReasoningContent,
-    streamingForConversationId,
-    isStreaming,
-    isThinking,
-    clearStreamingMessage,
-    deleteConversation,
-    setActiveConversation,
-    setConversationProject,
-  } = useChatStore();
-
-  const { projects, getProject } = useProjectStore();
-
-  const activeConversation = conversations.find(
-    c => c.id === activeConversationId,
+  const activeConversationId = useChatStore(s => s.activeConversationId);
+  const activeConversation = useChatStore(s =>
+    s.conversations.find(c => c.id === s.activeConversationId),
   );
+  const streamingForConversationId = useChatStore(s => s.streamingForConversationId);
+  const isStreaming = useChatStore(s => s.isStreaming);
+  const isThinking = useChatStore(s => s.isThinking);
+  const hasStreamingText = useHasActiveStreamText();
+  const createConversation = useChatStore(s => s.createConversation);
+  const addMessage = useChatStore(s => s.addMessage);
+  const updateMessageContent = useChatStore(s => s.updateMessageContent);
+  const updateMessageTurnKind = useChatStore(s => s.updateMessageTurnKind);
+  const deleteMessagesAfter = useChatStore(s => s.deleteMessagesAfter);
+  const clearStreamingMessage = useChatStore(s => s.clearStreamingMessage);
+  const deleteConversation = useChatStore(s => s.deleteConversation);
+  const setActiveConversation = useChatStore(s => s.setActiveConversation);
+  const setConversationProject = useChatStore(s => s.setConversationProject);
+
+  const projects = useProjectStore(s => s.projects);
+  const getProject = useProjectStore(s => s.getProject);
 
   // Which text model is active, from the ONE hook that answers it (remote preferred over local, local
   // resolved by activeModelService). This screen used to re-derive it with its own copy of the rule,
@@ -298,19 +294,31 @@ export const useChatScreen = () => {
   // Replies generating on paired devices. Empty unless Pro's chat-stream service is running.
   const remotePreviews = useRemoteChatStreamPreviews(activeConversationId);
   const localDeviceId = useSyncIdentityStore(s => s.localDeviceId);
-  const displayMessages = getDisplayMessages(
-    activeConversation?.messages || [],
-    {
+  const displayMessages = useMemo(
+    () =>
+      getDisplayMessages(activeConversation?.messages || [], {
+        isThinking,
+        streamingMessage: '',
+        streamingReasoningContent: '',
+        hasStreamingText,
+        isStreamingForThisConversation,
+        isModelLoading,
+        loadingModelName: loadingModel?.name,
+        isGeneratingForThisConversation,
+        remotePreviews,
+        localDeviceId,
+      }),
+    [
+      activeConversation?.messages,
       isThinking,
-      streamingMessage,
-      streamingReasoningContent,
+      hasStreamingText,
       isStreamingForThisConversation,
       isModelLoading,
-      loadingModelName: loadingModel?.name,
+      loadingModel?.name,
       isGeneratingForThisConversation,
       remotePreviews,
       localDeviceId,
-    },
+    ],
   );
 
   const animateLastN = useChatPresentationLifecycle(

--- a/src/screens/HomeScreen/hooks/useHomeScreen.ts
+++ b/src/screens/HomeScreen/hooks/useHomeScreen.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useMemo, useState, useRef, useCallback } from 'react';
 import { InteractionManager } from 'react-native';
 import {
   AlertState,
@@ -88,8 +88,11 @@ export const useHomeScreen = (navigation: HomeScreenNavigationProp) => {
     generatedImages,
   } = useAppStore();
 
-  const { conversations, setActiveConversation, deleteConversation } =
-    useChatStore();
+  const conversations = useChatStore(state => state.conversations);
+  const setActiveConversation = useChatStore(
+    state => state.setActiveConversation,
+  );
+  const deleteConversation = useChatStore(state => state.deleteConversation);
 
   // Remote server store for remote models
   const {
@@ -354,7 +357,10 @@ export const useHomeScreen = (navigation: HomeScreenNavigationProp) => {
     null;
   // Ordered, not just the store's first four - otherwise "Recent" can list older chats than
   // the ones just used, and disagrees with the Chats list and desktop.
-  const recentConversations = mostRecentConversations(conversations, 4);
+  const recentConversations = useMemo(
+    () => mostRecentConversations(conversations, 4),
+    [conversations],
+  );
 
   // Get all remote text models — includes vision-language models since they do text generation too
   const remoteTextModels: RemoteModel[] = remoteServers.flatMap(

--- a/src/screens/ModelSettingsScreen/TextGenerationSection.tsx
+++ b/src/screens/ModelSettingsScreen/TextGenerationSection.tsx
@@ -39,11 +39,11 @@ export const TextGenerationSection: React.FC = () => {
       ) : (
         <>
           <SliderSetting testID="llama-temperature" {...llama.temperature} />
-          <SliderSetting testID="llama-max-tokens" {...llama.maxTokens} />
           <SliderSetting
             testID="llama-context-length"
             {...llama.contextLength}
           />
+          <SliderSetting testID="llama-max-tokens" {...llama.maxTokens} />
           <ThinkingBudgetSelector />
         </>
       )}

--- a/src/screens/ProjectChatsScreen.tsx
+++ b/src/screens/ProjectChatsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   View,
   Text,
@@ -21,11 +21,13 @@ import { useChatStore, useProjectStore, useAppStore } from '../stores';
 import { Conversation } from '../types';
 import { RootStackParamList } from '../navigation/types';
 import { useConversationPreviewLine } from '../hooks/useConversationPreviewLine';
+import { conversationsForProject } from '../utils/projectConversations';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 type RouteProps = RouteProp<RootStackParamList, 'ProjectChats'>;
 
 const formatDate = (dateString: string): string => formatWhen(dateString);
+const chatKey = (conversation: Conversation): string => conversation.id;
 
 const createStyles = (colors: ThemeColors, shadows: ThemeShadows) => ({
   container: {
@@ -155,17 +157,23 @@ export const ProjectChatsScreen: React.FC = () => {
   const styles = useThemedStyles(createStyles);
   const [alertState, setAlertState] = useState<AlertState>(initialAlertState);
 
-  const { getProject } = useProjectStore();
-  const { conversations, deleteConversation, setActiveConversation, createConversation } = useChatStore();
-  const { downloadedModels, activeModelId } = useAppStore();
+  const project = useProjectStore(state =>
+    state.projects.find(candidate => candidate.id === projectId),
+  );
+  const conversations = useChatStore(state => state.conversations);
+  const deleteConversation = useChatStore(state => state.deleteConversation);
+  const setActiveConversation = useChatStore(state => state.setActiveConversation);
+  const createConversation = useChatStore(state => state.createConversation);
+  const downloadedModels = useAppStore(state => state.downloadedModels);
+  const activeModelId = useAppStore(state => state.activeModelId);
 
-  const project = getProject(projectId);
   const hasModels = downloadedModels.length > 0;
 
   // Get chats for this project
-  const projectChats = conversations
-    .filter((c) => c.projectId === projectId)
-    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+  const projectChats = useMemo(
+    () => conversationsForProject(conversations, projectId),
+    [conversations, projectId],
+  );
 
   const handleChatPress = (conversation: Conversation) => {
     setActiveConversation(conversation.id);
@@ -283,7 +291,7 @@ export const ProjectChatsScreen: React.FC = () => {
         <FlatList
           data={projectChats}
           renderItem={renderChat}
-          keyExtractor={(item) => item.id}
+          keyExtractor={chatKey}
           contentContainerStyle={styles.listContent}
           showsVerticalScrollIndicator={false}
           removeClippedSubviews={Platform.OS !== 'android'}

--- a/src/screens/ProjectDetailScreen.tsx
+++ b/src/screens/ProjectDetailScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
@@ -21,6 +21,7 @@ import { RootStackParamList } from '../navigation/types';
 import { KnowledgeBaseSection } from './ProjectDetailKnowledgeBaseSection';
 import { formatWhen } from '../utils/localTime';
 import { useConversationPreviewLine } from '../hooks/useConversationPreviewLine';
+import { conversationsForProject } from '../utils/projectConversations';
 import { PROJECT_DELETE_FALLBACK_REASON } from '../stores/projectDeleteOutcome';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
@@ -35,25 +36,24 @@ export const ProjectDetailScreen: React.FC = () => {
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
 
-  const { getProject, deleteProject } = useProjectStore();
-  const {
-    conversations,
-    deleteConversation,
-    setActiveConversation,
-    createConversation,
-  } = useChatStore();
-  const { downloadedModels, activeModelId } = useAppStore();
+  const project = useProjectStore(state =>
+    state.projects.find(candidate => candidate.id === projectId),
+  );
+  const deleteProject = useProjectStore(state => state.deleteProject);
+  const conversations = useChatStore(state => state.conversations);
+  const deleteConversation = useChatStore(state => state.deleteConversation);
+  const setActiveConversation = useChatStore(state => state.setActiveConversation);
+  const createConversation = useChatStore(state => state.createConversation);
+  const downloadedModels = useAppStore(state => state.downloadedModels);
+  const activeModelId = useAppStore(state => state.activeModelId);
 
-  const project = getProject(projectId);
   const hasModels = downloadedModels.length > 0;
 
   // Get chats for this project
-  const projectChats = conversations
-    .filter(c => c.projectId === projectId)
-    .sort(
-      (a, b) =>
-        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-    );
+  const projectChats = useMemo(
+    () => conversationsForProject(conversations, projectId),
+    [conversations, projectId],
+  );
 
   const handleChatPress = (conversation: Conversation) => {
     setActiveConversation(conversation.id);

--- a/src/screens/ProjectsScreen.tsx
+++ b/src/screens/ProjectsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   View,
   Text,
@@ -25,6 +25,7 @@ import { useProjectStore, useChatStore } from '../stores';
 import { Project } from '../types';
 import { RootStackParamList, MainTabParamList } from '../navigation/types';
 import { PROJECT_DELETE_FALLBACK_REASON } from '../stores/projectDeleteOutcome';
+import { projectChatCounts } from '../utils/projectConversations';
 
 type NavigationProp = CompositeNavigationProp<
   BottomTabNavigationProp<MainTabParamList, 'ProjectsTab'>,
@@ -36,14 +37,15 @@ export const ProjectsScreen: React.FC = () => {
   const focusTrigger = useFocusTrigger();
   const { colors } = useTheme();
   const styles = useThemedStyles(createStyles);
-  const { projects, deleteProject } = useProjectStore();
-  const { conversations } = useChatStore();
+  const projects = useProjectStore(state => state.projects);
+  const deleteProject = useProjectStore(state => state.deleteProject);
+  const conversations = useChatStore(state => state.conversations);
   const [alertState, setAlertState] = useState<AlertState>(initialAlertState);
 
-  // Get chat count for a project
-  const getChatCount = (projectId: string) => {
-    return conversations.filter((c) => c.projectId === projectId).length;
-  };
+  const chatCounts = useMemo(
+    () => projectChatCounts(conversations),
+    [conversations],
+  );
 
   const handleProjectPress = (project: Project) => {
     navigation.navigate('ProjectDetail', { projectId: project.id });
@@ -91,7 +93,7 @@ export const ProjectsScreen: React.FC = () => {
   };
 
   const renderProject = ({ item, index }: { item: Project; index: number }) => {
-    const chatCount = getChatCount(item.id);
+    const chatCount = chatCounts[item.id] ?? 0;
 
     return (
       <Swipeable

--- a/src/services/contextCompaction.ts
+++ b/src/services/contextCompaction.ts
@@ -86,9 +86,21 @@ class ContextCompactionService {
    * Falls back to trim-only if summarization fails.
    */
   async compact(
-    opts: { conversationId: string; systemPrompt: string; allMessages: Message[]; previousSummary?: string },
+    opts: {
+      conversationId: string;
+      systemPrompt: string;
+      allMessages: Message[];
+      previousSummary?: string;
+      activeTurnStartMessageId?: string;
+    },
   ): Promise<Message[]> {
-    const { conversationId, systemPrompt, allMessages, previousSummary } = opts;
+    const {
+      conversationId,
+      systemPrompt,
+      allMessages,
+      previousSummary,
+      activeTurnStartMessageId,
+    } = opts;
     this.setCompacting(true);
     try {
       await llmService.clearKVCache(true);
@@ -99,13 +111,25 @@ class ContextCompactionService {
       const recentTokenBudget = Math.max(0, Math.floor(ctxLength * CONTEXT_PROMPT_BUDGET_RATIO) - summaryTokenBudget - systemTokens);
 
       const nonSystem = allMessages.filter(m => m.role !== 'system');
+      const activeTurnStart = activeTurnStartMessageId
+        ? nonSystem.findIndex(message => message.id === activeTurnStartMessageId)
+        : -1;
+      const protectedMessages = activeTurnStart >= 0
+        ? nonSystem.slice(activeTurnStart)
+        : [];
+      const compactableMessages = activeTurnStart >= 0
+        ? nonSystem.slice(0, activeTurnStart)
+        : nonSystem;
       logger.log(`[ContextCompaction] ${nonSystem.length} messages, ctx=${ctxLength}, summaryBudget=${summaryTokenBudget}, recentBudget=${recentTokenBudget}`);
 
       // Walk backwards — keep recent messages that fit in the recent budget
       const recentMessages: Message[] = [];
       let recentTokensUsed = 0;
-      for (let i = nonSystem.length - 1; i >= 0; i--) {
-        const msg = nonSystem[i];
+      for (const message of protectedMessages) {
+        recentTokensUsed += await this.countTokens(message.content);
+      }
+      for (let i = compactableMessages.length - 1; i >= 0; i--) {
+        const msg = compactableMessages[i];
         const tokens = await this.countTokens(msg.content);
         if (recentTokensUsed + tokens <= recentTokenBudget) {
           recentMessages.unshift(msg);
@@ -121,7 +145,10 @@ class ContextCompactionService {
       }
 
       // Everything before recent is "old"
-      const oldMessages = nonSystem.slice(0, nonSystem.length - recentMessages.length);
+      const oldMessages = compactableMessages.slice(
+        0,
+        compactableMessages.length - recentMessages.length,
+      );
 
       // If there are no old messages, no compaction needed
       if (oldMessages.length === 0) {
@@ -129,6 +156,7 @@ class ContextCompactionService {
         return [
           { id: 'system', role: 'system', content: systemPrompt, timestamp: 0 },
           ...recentMessages,
+          ...protectedMessages,
         ];
       }
 
@@ -162,9 +190,9 @@ class ContextCompactionService {
         });
       }
 
-      result.push(...recentMessages);
+      result.push(...recentMessages, ...protectedMessages);
 
-      logger.log(`[ContextCompaction] Compacted: ${nonSystem.length} → ${recentMessages.length} messages + summary (${summary ? summary.length : 0} chars)`);
+      logger.log(`[ContextCompaction] Compacted: ${nonSystem.length} → ${recentMessages.length + protectedMessages.length} messages + summary (${summary ? summary.length : 0} chars)`);
       return result;
     } finally {
       this.setCompacting(false);

--- a/src/services/generationRemoteHelpers.ts
+++ b/src/services/generationRemoteHelpers.ts
@@ -7,6 +7,7 @@ import { useAppStore, useChatStore, useRemoteServerStore } from '../stores';
 import { runToolLoop } from './generationToolLoop';
 import type { GenerationOptions, CompletionResult } from './providers/types';
 import logger from '../utils/logger';
+import { providerRegistry } from './providers';
 import {
   FLUSH_INTERVAL_MS,
   buildGenerationMetaImpl,
@@ -38,7 +39,7 @@ export async function generateRemoteResponseImpl(
   // abortRequested is reset by the next generation's prepareGeneration().
   const { signal: generationSignal } = svc.currentRemoteAbortController;
 
-  const { temperature, maxTokens, topP, thinkingEnabled } =
+  const { temperature, maxTokens, topP, thinkingEnabled, reasoningBudget } =
     useAppStore.getState().settings;
   const options: GenerationOptions = {
     temperature,
@@ -46,61 +47,61 @@ export async function generateRemoteResponseImpl(
     topP,
     stopSequences: [],
     enableThinking: thinkingEnabled && provider.capabilities.supportsThinking,
+    reasoningBudget,
+  };
+
+  const callbacks = {
+    onToken: (token: string) => {
+      if (generationSignal.aborted) return;
+      if (!firstTokenReceived) {
+        firstTokenReceived = true;
+        svc.remoteTimeToFirstToken = svc.state.startTime
+          ? (Date.now() - svc.state.startTime) / 1000
+          : undefined;
+        svc.updateState({ isThinking: false });
+        onFirstToken?.();
+      }
+      svc.state.streamingContent += token;
+      svc.tokenBuffer += token;
+      if (!svc.flushTimer) {
+        svc.flushTimer = setTimeout(
+          () => svc.flushTokenBuffer(),
+          FLUSH_INTERVAL_MS,
+        );
+      }
+    },
+    onReasoning: (content: string) => {
+      if (generationSignal.aborted) return;
+      svc.reasoningBuffer += content;
+      svc.totalReasoningLength += content.length;
+      if (!svc.flushTimer) {
+        svc.flushTimer = setTimeout(
+          () => svc.flushTokenBuffer(),
+          FLUSH_INTERVAL_MS,
+        );
+      }
+    },
+    onComplete: (_result: CompletionResult) => {
+      if (generationSignal.aborted) return;
+      svc.forceFlushTokens();
+      const generationTime = svc.state.startTime
+        ? Date.now() - svc.state.startTime
+        : undefined;
+      chatStore.finalizeStreamingMessage(
+        conversationId,
+        generationTime,
+        buildGenerationMetaImpl(svc),
+      );
+      svc.checkSharePrompt();
+      svc.resetState();
+    },
+    onError: (error: Error) => {
+      throw error;
+    },
   };
 
   try {
-    await provider.generate(messages, options, {
-      onToken: (token: string) => {
-        if (generationSignal.aborted) return;
-        if (!firstTokenReceived) {
-          firstTokenReceived = true;
-          svc.remoteTimeToFirstToken = svc.state.startTime
-            ? (Date.now() - svc.state.startTime) / 1000
-            : undefined;
-          svc.updateState({ isThinking: false });
-          onFirstToken?.();
-        }
-        svc.state.streamingContent += token;
-        svc.tokenBuffer += token;
-        if (!svc.flushTimer) {
-          svc.flushTimer = setTimeout(
-            () => svc.flushTokenBuffer(),
-            FLUSH_INTERVAL_MS,
-          );
-        }
-      },
-      onReasoning: (content: string) => {
-        if (generationSignal.aborted) return;
-        svc.reasoningBuffer += content;
-        svc.totalReasoningLength += content.length;
-        if (!svc.flushTimer) {
-          svc.flushTimer = setTimeout(
-            () => svc.flushTokenBuffer(),
-            FLUSH_INTERVAL_MS,
-          );
-        }
-      },
-      onComplete: (_result: CompletionResult) => {
-        if (generationSignal.aborted) return;
-        svc.forceFlushTokens();
-        const generationTime = svc.state.startTime
-          ? Date.now() - svc.state.startTime
-          : undefined;
-        chatStore.finalizeStreamingMessage(
-          conversationId,
-          generationTime,
-          buildGenerationMetaImpl(svc),
-        );
-        svc.checkSharePrompt();
-        svc.resetState();
-      },
-      onError: (error: Error) => {
-        if (generationSignal.aborted) return;
-        logger.error('[GenerationService] Remote generation error:', error);
-        keepShownPartialOnError(svc, conversationId);
-        throw error;
-      },
-    });
+    await provider.generate(messages, options, callbacks);
   } catch (error) {
     if (generationSignal.aborted) return;
     logger.error('[GenerationService] Remote generation error:', error);
@@ -108,6 +109,48 @@ export async function generateRemoteResponseImpl(
     const failedServerId = useRemoteServerStore.getState().activeServerId;
     if (failedServerId)
       useRemoteServerStore.getState().updateServerHealth(failedServerId, false);
+    const local = providerRegistry.getProvider('local');
+    if (local?.isModelLoaded?.()) {
+      svc.forceFlushTokens();
+      chatStore.clearStreamingMessage();
+      svc.state.streamingContent = '';
+      svc.tokenBuffer = '';
+      svc.reasoningBuffer = '';
+      svc.remoteTimeToFirstToken = undefined;
+      firstTokenReceived = false;
+      const failedName =
+        useRemoteServerStore.getState().getActiveServer()?.name ??
+        'Remote model';
+      const loadedId = local.getLoadedModelId?.();
+      const nextName =
+        useAppStore.getState().downloadedModels.find(
+          model => model.id === loadedId || model.filePath === loadedId,
+        )?.name ?? loadedId ?? 'Local model';
+      const rawReason =
+        error instanceof Error ? error.message.trim().split('\n')[0] : '';
+      const reason = rawReason.length > 160
+        ? `${rawReason.slice(0, 157).trimEnd()}...`
+        : rawReason;
+      chatStore.addMessage(conversationId, {
+        role: 'tool',
+        toolName: 'model_fallback',
+        content: `${failedName} could not answer (${reason || 'unknown error'}). ${nextName} answered instead.`,
+      });
+      chatStore.startStreaming(conversationId);
+      svc.updateState({ isThinking: true, startTime: Date.now() });
+      svc.answeringModelName = nextName;
+      svc.answeringLocally = true;
+      await local.generate(
+        messages,
+        {
+          ...options,
+          enableThinking:
+            thinkingEnabled && local.capabilities.supportsThinking,
+        },
+        callbacks,
+      );
+      return;
+    }
     keepShownPartialOnError(svc, conversationId);
     throw error;
   } finally {

--- a/src/services/generationService.ts
+++ b/src/services/generationService.ts
@@ -62,6 +62,8 @@ class GenerationService {
   private queueProcessor: QueueProcessor | null = null;
   private currentRemoteAbortController: AbortController | null = null;
   private remoteTimeToFirstToken: number | undefined;
+  private answeringModelName: string | undefined;
+  private answeringLocally = false;
 
   // Token batching — collect tokens and flush to UI at a controlled rate
   private tokenBuffer: string = '';
@@ -366,6 +368,8 @@ class GenerationService {
     this.reasoningBuffer = '';
     this.totalReasoningLength = 0;
     this.remoteTimeToFirstToken = undefined;
+    this.answeringModelName = undefined;
+    this.answeringLocally = false;
     this.updateState({
       isGenerating: false,
       isThinking: false,

--- a/src/services/generationServiceHelpers.ts
+++ b/src/services/generationServiceHelpers.ts
@@ -103,12 +103,13 @@ function buildLiteRTMeta(
 
 export function buildGenerationMetaImpl(svc: any): GenerationMeta {
   const meta = buildBaseGenerationMeta(svc);
+  if (svc.answeringModelName) meta.modelName = svc.answeringModelName;
   const routed = svc.state?.routedToolNames;
   if (Array.isArray(routed) && routed.length > 0) meta.routedToolNames = routed;
   return meta;
 }
 function buildBaseGenerationMeta(svc: any): GenerationMeta {
-  if (svc.isUsingRemoteProvider()) {
+  if (svc.isUsingRemoteProvider() && !svc.answeringLocally) {
     const remoteStore = useRemoteServerStore.getState();
     const activeServer = remoteStore.getActiveServer();
     const contentLength =

--- a/src/services/generationToolLoop.ts
+++ b/src/services/generationToolLoop.ts
@@ -28,12 +28,13 @@ import {
 } from '../utils/messageContent';
 import {
   callsWithinToolBudget,
-  finalResponseFromToolResults,
   normalizeMaxToolCalls,
   toolLimitFinalAnswerInstruction,
   toolPromptChars,
   toolResultCharBudget,
 } from '@offgrid/models';
+const toolResultsFinalAnswerInstruction = (): string =>
+  'The tool work is complete. Answer the user now using the completed tool results in the conversation. Do not call another tool, output tool-call syntax, or repeat raw tool output without explaining it.';
 const currentMaxToolSteps = (): number => {
   const configured = useAppStore.getState().settings.maxToolCalls;
   return normalizeMaxToolCalls(configured);
@@ -489,6 +490,7 @@ function remoteGenerateOnce(
     topP: settings.topP,
     tools,
     enableThinking: thinkingEnabled,
+    reasoningBudget: settings.reasoningBudget,
   };
   let _fullContent = '';
   let streamed = false;
@@ -773,6 +775,7 @@ async function callLiteRTForLoop(
   fullResponse: string;
   toolCalls: ToolCall[];
   toolStepLimitReached?: boolean;
+  toolFinalizationRequired?: boolean;
   completedToolMessages?: Message[];
   completedToolResults?: string[];
 }> {
@@ -837,12 +840,15 @@ async function callLiteRTForLoop(
       };
     }
     // Native SDK handles all tool→model cycles internally; toolCalls always empty here.
-    // If the model ran a tool but then produced NO final answer, surface the fetched
-    // data instead of discarding it (the user would otherwise see a blank / "(No
-    // response)" turn — Q5). The tool result is the honest answer the model failed to
-    // phrase; better a visible result than a dead end.
+    // Return completed tool context to the outer loop when the native cycle has no final answer.
     if (!fullResponse.trim() && outcome.results.length > 0) {
-      return { fullResponse: outcome.results.join('\n\n'), toolCalls: [] };
+      return {
+        fullResponse: '',
+        toolCalls: [],
+        toolFinalizationRequired: true,
+        completedToolMessages: outcome.messages,
+        completedToolResults: outcome.results,
+      };
     }
     return { fullResponse, toolCalls: [] };
   } catch (e: any) {
@@ -1036,6 +1042,7 @@ async function callLLMWithRetry(
   toolCalls: ToolCall[];
   interrupted?: boolean;
   toolStepLimitReached?: boolean;
+  toolFinalizationRequired?: boolean;
   completedToolMessages?: Message[];
   completedToolResults?: string[];
 }> {
@@ -1189,6 +1196,7 @@ function emitFinalResponse(
 }
 
 /** Run one final model pass with completed results and no available tool execution path. */
+// eslint-disable-next-line max-params -- context, stream state, history, limit, and completed native tool context are distinct inputs
 async function emitToolLimitFinalAnswer(
   ctx: ToolLoopContext,
   state: ToolLoopState,
@@ -1197,6 +1205,7 @@ async function emitToolLimitFinalAnswer(
   completed: {
     messages?: Message[];
     results?: string[];
+    instruction?: string;
   } = {},
 ): Promise<ToolLoopOutcome> {
   if (ctx.isAborted()) return { interrupted: true };
@@ -1212,7 +1221,7 @@ async function emitToolLimitFinalAnswer(
     {
       id: `tool-limit-final-${Date.now()}`,
       role: 'system',
-      content: toolLimitFinalAnswerInstruction(maximum),
+      content: completed.instruction ?? toolLimitFinalAnswerInstruction(maximum),
       timestamp: Date.now(),
     },
     ...loopMessages.filter(message => message.role !== 'system'),
@@ -1235,7 +1244,7 @@ async function emitToolLimitFinalAnswer(
   emitFinalResponse(
     ctx,
     state,
-    finalResponseFromToolResults(displayResponse, state.successfulToolResults),
+    displayResponse.trim(),
   );
   return { interrupted: false };
 }
@@ -1385,6 +1394,7 @@ export async function runToolLoop(
       toolCalls,
       interrupted,
       toolStepLimitReached,
+      toolFinalizationRequired,
       completedToolMessages,
       completedToolResults,
     } = await callLLMWithRetry(loopMessages, effectiveSchemas, {
@@ -1417,6 +1427,14 @@ export async function runToolLoop(
       });
     }
 
+    if (toolFinalizationRequired) {
+      return emitToolLimitFinalAnswer(ctx, state, loopMessages, maxToolSteps, {
+        messages: completedToolMessages,
+        results: completedToolResults,
+        instruction: toolResultsFinalAnswerInstruction(),
+      });
+    }
+
     const { effectiveToolCalls, displayResponse } = resolveToolCalls(
       fullResponse,
       toolCalls,
@@ -1439,27 +1457,9 @@ export async function runToolLoop(
         state.streamedContent = '';
         state.reasoningContent = '';
         state.firstTokenFired = false;
-        const fallbackOnStream = buildStreamHandler(ctx, state);
-        const { fullResponse: fallbackResp } = await callLLMWithRetry(
-          loopMessages,
-          [],
-          {
-            onStream: fallbackOnStream,
-            forceRemote: ctx.forceRemote,
-            disableThinking: true,
-            conversationId: ctx.conversationId,
-            ctx,
-          },
-        );
-        emitFinalResponse(
-          ctx,
-          state,
-          finalResponseFromToolResults(
-            fallbackResp,
-            state.successfulToolResults,
-          ),
-        );
-        return { interrupted: false };
+        return emitToolLimitFinalAnswer(ctx, state, loopMessages, maxToolSteps, {
+          instruction: toolResultsFinalAnswerInstruction(),
+        });
       }
       emitFinalResponse(ctx, state, displayResponse);
       return { interrupted: false };

--- a/src/services/providers/openAICompatibleProvider.ts
+++ b/src/services/providers/openAICompatibleProvider.ts
@@ -23,6 +23,7 @@ import type {
   OpenAIStreamState,
 } from './openAICompatibleTypes';
 import { remoteAuthorizationHeaders } from '../remoteTransportPolicy';
+import { openRouterReasoningPayload, REASONING_BUDGET_AUTO } from '@offgrid/models';
 
 export type { OpenAIChatMessage, OpenAIConfig } from './openAICompatibleTypes';
 
@@ -91,6 +92,12 @@ export class OpenAICompatibleProvider implements LLMProvider {
     options: GenerationOptions,
     thinkingEnabled: boolean
   ): Record<string, unknown> {
+    const reasoning = this.config.endpoint.includes('openrouter.ai')
+      ? openRouterReasoningPayload(
+          thinkingEnabled,
+          options.reasoningBudget ?? REASONING_BUDGET_AUTO,
+        )
+      : {};
     return {
       model: this.config.modelId,
       messages: openaiMessages,
@@ -109,6 +116,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
       // discovered capability — not the endpoint's port — keeps the "which server
       // accepts this?" decision in one place and free of implementation coupling.
       ...(this.modelCapabilities.acceptsThinkingKwarg && { chat_template_kwargs: { enable_thinking: thinkingEnabled } }),
+      ...reasoning,
     };
   }
 

--- a/src/services/providers/types.ts
+++ b/src/services/providers/types.ts
@@ -76,6 +76,8 @@ export interface GenerationOptions {
   stopSequences?: string[];
   /** Whether to enable thinking/reasoning mode (Ollama: sends "think" param; others: parsed from response) */
   enableThinking?: boolean;
+  /** Provider-neutral reasoning budget in tokens. */
+  reasoningBudget?: number;
 }
 
 /** Tool definition for function calling */
@@ -163,4 +165,3 @@ export interface LLMProvider {
   /** Clean up resources */
   dispose?(): Promise<void>;
 }
-

--- a/src/services/remoteMediaRuntime.ts
+++ b/src/services/remoteMediaRuntime.ts
@@ -2,8 +2,6 @@ import { remoteServerManager } from './remoteServerManager';
 import type { RemoteMediaModelIds, RemoteServer } from '../types';
 import { REMOTE_FETCH_REDIRECT_POLICY, remoteAuthorizationHeaders } from './remoteTransportPolicy';
 
-const REQUEST_TIMEOUT_MS = 60_000;
-
 export interface RemoteImageResult {
   base64?: string;
   url?: string;
@@ -37,7 +35,6 @@ async function request<T>(
   const controller = new AbortController();
   const abort = () => controller.abort();
   signal?.addEventListener('abort', abort, { once: true });
-  const timeout = setTimeout(abort, REQUEST_TIMEOUT_MS);
   try {
     const apiKey = await remoteServerManager.getApiKey(server.id);
     if (controller.signal.aborted) throw new Error('Remote request cancelled');
@@ -62,7 +59,6 @@ async function request<T>(
     if (controller.signal.aborted) throw new Error('Remote request cancelled');
     throw error;
   } finally {
-    clearTimeout(timeout);
     signal?.removeEventListener('abort', abort);
   }
 }

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- one persisted store keeps chat mutations atomic */
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { Message, Conversation, GenerationMeta } from '../types';
@@ -174,7 +175,12 @@ const NO_REPLY_FORMING: StreamingFields = {
   isThinking: false,
 };
 
-const chatStorage = createHydrationGatedStorage<PersistedChatState>();
+const chatStorage = createHydrationGatedStorage<PersistedChatState>(
+  undefined,
+  (previous, next) =>
+    previous.conversations === next.conversations &&
+    previous.activeConversationId === next.activeConversationId,
+);
 
 export const useChatStore = create<ChatState>()(
   persist(

--- a/src/utils/hydrationGatedStorage.ts
+++ b/src/utils/hydrationGatedStorage.ts
@@ -14,17 +14,36 @@ export interface HydrationGatedStorage<S> {
 /** Prevent boot-time defaults from replacing saved state before Zustand finishes hydration. */
 export function createHydrationGatedStorage<S>(
   base: StateStorage = AsyncStorage,
+  unchanged?: (previous: S, next: S) => boolean,
 ): HydrationGatedStorage<S> {
   let hydrated = false;
+  let lastWritten: S | undefined;
   const json = createJSONStorage<S>(() => base);
   if (!json) throw new Error('JSON storage is unavailable');
 
   return {
     storage: {
-      getItem: name => json.getItem(name),
-      setItem: (name, value) =>
-        hydrated ? json.setItem(name, value) : undefined,
-      removeItem: name => (hydrated ? json.removeItem(name) : undefined),
+      getItem: async name => {
+        const value = await json.getItem(name);
+        lastWritten = value?.state;
+        return value;
+      },
+      setItem: (name, value) => {
+        if (!hydrated) return undefined;
+        if (
+          lastWritten !== undefined &&
+          unchanged?.(lastWritten, value.state)
+        ) {
+          return undefined;
+        }
+        lastWritten = value.state;
+        return json.setItem(name, value);
+      },
+      removeItem: name => {
+        if (!hydrated) return undefined;
+        lastWritten = undefined;
+        return json.removeItem(name);
+      },
     },
     markHydrated: () => {
       hydrated = true;

--- a/src/utils/projectConversations.ts
+++ b/src/utils/projectConversations.ts
@@ -1,0 +1,24 @@
+import type { Conversation } from '../types';
+import { byRecentActivity } from './conversationOrdering';
+
+export function projectChatCounts(
+  conversations: readonly Conversation[],
+): Readonly<Record<string, number>> {
+  const counts: Record<string, number> = {};
+  for (const conversation of conversations) {
+    if (conversation.projectId) {
+      counts[conversation.projectId] =
+        (counts[conversation.projectId] ?? 0) + 1;
+    }
+  }
+  return counts;
+}
+
+export function conversationsForProject(
+  conversations: readonly Conversation[],
+  projectId: string,
+): Conversation[] {
+  return byRecentActivity(
+    conversations.filter(conversation => conversation.projectId === projectId),
+  );
+}


### PR DESCRIPTION
## Summary
- preserve active chat turns during context compaction
- recover failed remote and tool responses with clear model state
- isolate live streaming updates from committed chat rows
- keep focused input active and narrow reactive store subscriptions
- skip unchanged persistence work and memoize project chat summaries
- refine generation settings and update the Pro sync dependency

## Verification
Not run, as requested.

## Related Pro change
- https://github.com/off-grid-ai/mobile-pro/pull/68