### PR TITLE
CHAT-01: compact Mobile chats and show generation details

### DIFF
--- a/__tests__/unit/services/contextCompaction.test.ts
+++ b/__tests__/unit/services/contextCompaction.test.ts
@@ -210,22 +210,6 @@ describe('compact', () => {
     expect(mockedUpdateCompactionState).not.toHaveBeenCalled();
   });
 
-  it('truncates last user message when it alone exceeds recent budget', async () => {
-    mockTokenCounts(2000);
-
-    const longContent = 'x'.repeat(8000);
-    const messages = [
-      createMessage({ role: 'system', content: 'System' }),
-      createMessage({ role: 'user', content: longContent }),
-    ];
-
-    const result = await compactWith(messages);
-
-    const userMsg = result.find(m => m.role === 'user');
-    expect(userMsg).toBeDefined();
-    expect(userMsg!.content.length).toBeLessThan(longContent.length);
-  });
-
   it('uses actual context length from settings', async () => {
     mockedLlmService.getPerformanceSettings.mockReturnValue({ contextLength: 512 } as any);
     mockedLlmService.getTokenCount.mockImplementation((text: string) =>

--- a/src/components/ChatMessage/components/GenerationMeta.tsx
+++ b/src/components/ChatMessage/components/GenerationMeta.tsx
@@ -13,6 +13,9 @@ type MetaItem = { key: string; label: string; maxLines?: number };
 function formatOptionalMeta(meta: NonNullable<Message['generationMeta']>, tps: number | null | undefined): MetaItem[] {
   const m = meta;
   const entries: Array<[string, string | undefined, number?]> = [
+    ['context', m.contextPromptTokens && m.contextWindowTokens
+      ? `Context: ${m.contextEstimate ? '~' : ''}${Math.round((m.contextPromptTokens / m.contextWindowTokens) * 100)}% used`
+      : undefined],
     ['model', m.modelName, 1],
     ['load', m.modelLoadTimeSeconds != null && m.modelLoadTimeSeconds > 0 ? `load ${m.modelLoadTimeSeconds.toFixed(1)}s` : undefined],
     ['prefill', m.prefillTokensPerSecond != null && m.prefillTokensPerSecond > 0 ? `prefill ${m.prefillTokensPerSecond.toFixed(0)} tok/s` : undefined],

--- a/src/components/ChatMessage/components/GenerationMeta.tsx
+++ b/src/components/ChatMessage/components/GenerationMeta.tsx
@@ -12,10 +12,13 @@ type MetaItem = { key: string; label: string; maxLines?: number };
 
 function formatOptionalMeta(meta: NonNullable<Message['generationMeta']>, tps: number | null | undefined): MetaItem[] {
   const m = meta;
-  const entries: Array<[string, string | undefined, number?]> = [
-    ['context', m.contextPromptTokens && m.contextWindowTokens
+  const contextLabel = m.contextPromptTokens
+    ? m.contextWindowTokens
       ? `Context: ${m.contextEstimate ? '~' : ''}${Math.round((m.contextPromptTokens / m.contextWindowTokens) * 100)}% used`
-      : undefined],
+      : `Context: ${m.contextEstimate ? '~' : ''}${m.contextPromptTokens} tokens used (limit unknown)`
+    : undefined;
+  const entries: Array<[string, string | undefined, number?]> = [
+    ['context', contextLabel],
     ['model', m.modelName, 1],
     ['load', m.modelLoadTimeSeconds != null && m.modelLoadTimeSeconds > 0 ? `load ${m.modelLoadTimeSeconds.toFixed(1)}s` : undefined],
     ['prefill', m.prefillTokensPerSecond != null && m.prefillTokensPerSecond > 0 ? `prefill ${m.prefillTokensPerSecond.toFixed(0)} tok/s` : undefined],

--- a/src/components/RemoteServerEditor/useRemoteServerForm.ts
+++ b/src/components/RemoteServerEditor/useRemoteServerForm.ts
@@ -136,12 +136,9 @@ export function useRemoteServerForm({
     } else {
       newErrors.endpoint = 'Endpoint URL is required';
     }
-    if (textContextWindowTokens && (!Number.isSafeInteger(Number(textContextWindowTokens)) || Number(textContextWindowTokens) < 1024)) {
-      newErrors.textContextWindowTokens = 'Enter at least 1024 tokens';
-    }
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
-  }, [name, endpoint, textContextWindowTokens]);
+  }, [name, endpoint]);
 
   const applySuccessfulConnection = useCallback((result: ServerTestResult) => {
     const modelCount =

--- a/src/components/RemoteServerEditor/useRemoteServerForm.ts
+++ b/src/components/RemoteServerEditor/useRemoteServerForm.ts
@@ -46,6 +46,7 @@ function applyDiscoveredModelIds(
   setters.voice(current => current || result.mediaModels?.voice || '');
 }
 
+// eslint-disable-next-line max-lines-per-function
 export function useRemoteServerForm({
   server,
   visible,
@@ -57,6 +58,7 @@ export function useRemoteServerForm({
   const [apiKey, setApiKey] = useState('');
   const [notes, setNotes] = useState('');
   const [textModelId, setTextModelId] = useState('');
+  const [textContextWindowTokens, setTextContextWindowTokens] = useState('');
   const [imageModelId, setImageModelId] = useState('');
   const [transcriptionModelId, setTranscriptionModelId] = useState('');
   const [voiceModelId, setVoiceModelId] = useState('');
@@ -83,6 +85,7 @@ export function useRemoteServerForm({
       setEndpoint(server.endpoint);
       setNotes(server.notes || '');
       setTextModelId(server.mediaModels?.text || '');
+      setTextContextWindowTokens(server.textContextWindowTokens ? String(server.textContextWindowTokens) : '');
       setImageModelId(server.mediaModels?.image || '');
       setTranscriptionModelId(server.mediaModels?.transcription || '');
       setVoiceModelId(server.mediaModels?.voice || '');
@@ -102,6 +105,7 @@ export function useRemoteServerForm({
       setApiKey('');
       setNotes('');
       setTextModelId('');
+      setTextContextWindowTokens('');
       setImageModelId('');
       setTranscriptionModelId('');
       setVoiceModelId('');
@@ -132,9 +136,12 @@ export function useRemoteServerForm({
     } else {
       newErrors.endpoint = 'Endpoint URL is required';
     }
+    if (textContextWindowTokens && (!Number.isSafeInteger(Number(textContextWindowTokens)) || Number(textContextWindowTokens) < 1024)) {
+      newErrors.textContextWindowTokens = 'Enter at least 1024 tokens';
+    }
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
-  }, [name, endpoint]);
+  }, [name, endpoint, textContextWindowTokens]);
 
   const applySuccessfulConnection = useCallback((result: ServerTestResult) => {
     const modelCount =
@@ -219,6 +226,7 @@ export function useRemoteServerForm({
     }
   }, [endpoint, apiKey, applySuccessfulConnection, validateForm]);
 
+  // eslint-disable-next-line complexity
   const saveServer = useCallback(async () => {
     try {
       const mediaModels = {
@@ -263,6 +271,7 @@ export function useRemoteServerForm({
           notes,
           apiKey,
           mediaModels: desktopManaged ? server.mediaModels : mediaModels,
+          textContextWindowTokens: textContextWindowTokens ? Number(textContextWindowTokens) : undefined,
           modelCatalog,
           modelManagement,
         });
@@ -294,6 +303,7 @@ export function useRemoteServerForm({
           notes: notes || undefined,
           apiKey: apiKey || undefined,
           mediaModels: desktopManaged ? confirmedMediaModels : mediaModels,
+          textContextWindowTokens: textContextWindowTokens ? Number(textContextWindowTokens) : undefined,
           modelCatalog,
           modelManagement,
         });
@@ -334,6 +344,7 @@ export function useRemoteServerForm({
     apiKey,
     notes,
     textModelId,
+    textContextWindowTokens,
     imageModelId,
     transcriptionModelId,
     voiceModelId,
@@ -375,6 +386,8 @@ export function useRemoteServerForm({
     setNotes,
     textModelId,
     setTextModelId,
+    textContextWindowTokens,
+    setTextContextWindowTokens,
     imageModelId,
     setImageModelId,
     transcriptionModelId,

--- a/src/components/settings/textGenAdvancedSections.tsx
+++ b/src/components/settings/textGenAdvancedSections.tsx
@@ -239,7 +239,7 @@ export const ShowGenerationDetailsToggle: React.FC = () => {
   return (
     <SegmentedRow<'off' | 'on'>
       label="Show Generation Details"
-      description="Display GPU, model, tok/s, and image settings below each message"
+      description="Show context use, model, speed, and image settings below each reply"
       options={BOOL_OPTIONS}
       current={on ? 'on' : 'off'}
       onSelect={(id) => updateSettings({ showGenerationDetails: id === 'on' })}

--- a/src/screens/ChatScreen/useChatGenerationActions.ts
+++ b/src/screens/ChatScreen/useChatGenerationActions.ts
@@ -44,6 +44,7 @@ import {
   DownloadedModel,
   RemoteModel,
   CacheType,
+  GenerationMeta,
 } from '../../types';
 import logger from '../../utils/logger';
 import { ModelReadyOutcome, ensureReadyOrAlert } from './modelReadiness';
@@ -464,7 +465,27 @@ async function prepareContext(
   setDebugInfo: SetState<any>,
   systemPrompt: string,
   messages: Message[],
-): Promise<void> {
+): Promise<Pick<GenerationMeta, 'contextPromptTokens' | 'contextWindowTokens' | 'contextEstimate'> | undefined> {
+  const estimatedPromptTokens = Math.ceil(
+    JSON.stringify(messages.map(m => ({ role: m.role, content: m.content }))).length / 4,
+  );
+  const remoteStore = useRemoteServerStore.getState();
+  if (remoteStore.activeServerId) {
+    const server = remoteStore.getActiveServer();
+    const model = remoteStore.getActiveRemoteTextModel();
+    const contextWindowTokens =
+      (!remoteStore.activeRemoteTextModelId || server?.mediaModels?.text === remoteStore.activeRemoteTextModelId
+        ? server?.textContextWindowTokens
+        : undefined) ?? model?.capabilities.maxContextLength;
+    setDebugInfo(null);
+    return contextWindowTokens && contextWindowTokens > 0
+      ? {
+          contextPromptTokens: estimatedPromptTokens,
+          contextWindowTokens,
+          contextEstimate: true,
+        }
+      : undefined;
+  }
   try {
     const contextDebug = await llmService.getContextDebugInfo(messages);
     setDebugInfo({ systemPrompt, ...contextDebug });
@@ -474,16 +495,28 @@ async function prepareContext(
     ) {
       await llmService.clearKVCache(false).catch(() => {});
     }
+    const contextWindowTokens = contextDebug.maxContextLength || useAppStore.getState().settings.contextLength || APP_CONFIG.maxContextLength;
+    return {
+      contextPromptTokens: contextDebug.estimatedTokens || estimatedPromptTokens,
+      contextWindowTokens,
+      contextEstimate: true,
+    };
   } catch {
-    /* ignore */
+    const contextWindowTokens = useAppStore.getState().settings.contextLength || APP_CONFIG.maxContextLength;
+    return {
+      contextPromptTokens: estimatedPromptTokens,
+      contextWindowTokens,
+      contextEstimate: true,
+    };
   }
 }
 /** Run generation; if context is full, compact old messages and retry once. */
 async function generateWithCompactionRetry(
-  opts: { id: string; prompt: string; messages: Message[] },
+  opts: { id: string; prompt: string; messages: Message[]; setDebugInfo?: SetState<any> },
   enabledTools: string[],
   projectId?: string,
 ): Promise<boolean> {
+  const { setDebugInfo } = opts;
   const extCount = getToolExtensions().reduce(
     (n, e) => n + e.enabledToolCount(),
     0,
@@ -495,13 +528,18 @@ async function generateWithCompactionRetry(
     enabledTools.length + extCount,
   );
   if (capabilityIssue) throw new Error(capabilityIssue);
-  const gen = (msgs: Message[]) =>
-    enabledTools.length > 0 || extCount > 0
+  const gen = async (msgs: Message[]) => {
+    const contextUsage = setDebugInfo
+      ? await prepareContext(setDebugInfo, opts.prompt, msgs)
+      : undefined;
+    return enabledTools.length > 0 || extCount > 0
       ? generationService.generateWithTools(opts.id, msgs, {
           enabledToolIds: enabledTools,
           projectId,
+          contextUsage,
         })
-      : generationService.generateResponse(opts.id, msgs);
+      : generationService.generateResponse(opts.id, msgs, undefined, contextUsage);
+  };
   let turnInterrupted = false; // PER-TURN stop truth from the loop outcome (returned to the caller)
   try {
     const outcome = await gen(opts.messages);
@@ -696,13 +734,13 @@ export async function startGenerationFn(
     messageText,
     systemPrompt,
   );
-  await prepareContext(setDebugInfo, systemPrompt, messagesForContext);
   try {
     turnStopped = await generateWithCompactionRetry(
       {
         id: targetConversationId,
         prompt: systemPrompt,
         messages: messagesForContext,
+        setDebugInfo,
       },
       activeTools,
       conversation?.projectId,
@@ -1037,7 +1075,7 @@ export async function regenerateResponseFn(
   deps: GenerationDeps,
   call: RegenerateCall,
 ): Promise<void> {
-  const { userMessage, recordedKind } = call;
+  const { setDebugInfo, userMessage, recordedKind } = call;
   logger.log(
     `[RESEND-SM] regenerate start userMsg=${userMessage.id} conv=${
       deps.activeConversationId
@@ -1140,6 +1178,7 @@ export async function regenerateResponseFn(
         id: targetConversationId,
         prompt: systemPrompt,
         messages: [...prefix, ...filtered],
+        setDebugInfo,
       },
       activeTools,
       conversation?.projectId,

--- a/src/screens/ChatScreen/useChatGenerationActions.ts
+++ b/src/screens/ChatScreen/useChatGenerationActions.ts
@@ -471,12 +471,8 @@ async function prepareContext(
   );
   const remoteStore = useRemoteServerStore.getState();
   if (remoteStore.activeServerId) {
-    const server = remoteStore.getActiveServer();
-    const model = remoteStore.getActiveRemoteTextModel();
     const contextWindowTokens =
-      (!remoteStore.activeRemoteTextModelId || server?.mediaModels?.text === remoteStore.activeRemoteTextModelId
-        ? server?.textContextWindowTokens
-        : undefined) ?? model?.capabilities.maxContextLength;
+      useAppStore.getState().settings.contextLength || APP_CONFIG.maxContextLength;
     setDebugInfo(null);
     return {
       contextPromptTokens: estimatedPromptTokens,

--- a/src/screens/ChatScreen/useChatGenerationActions.ts
+++ b/src/screens/ChatScreen/useChatGenerationActions.ts
@@ -504,7 +504,7 @@ async function prepareContext(
     };
   }
 }
-/** Run generation; if context is full, compact old messages and retry once. */
+/** Compact before the prompt budget is full; keep the context-full retry as a fallback. */
 async function generateWithCompactionRetry(
   opts: { id: string; prompt: string; messages: Message[]; setDebugInfo?: SetState<any> },
   enabledTools: string[],
@@ -534,9 +534,29 @@ async function generateWithCompactionRetry(
         })
       : generationService.generateResponse(opts.id, msgs, undefined, contextUsage);
   };
+  const contextWindowTokens = useRemoteServerStore.getState().activeServerId
+    ? useAppStore.getState().settings.contextLength || APP_CONFIG.maxContextLength
+    : llmService.getPerformanceSettings().contextLength || APP_CONFIG.maxContextLength;
+  const estimatedPromptTokens = Math.ceil(
+    JSON.stringify(opts.messages.map(m => ({ role: m.role, content: m.content }))).length / 4,
+  );
+  let messagesForFirstAttempt = opts.messages;
+  if (
+    estimatedPromptTokens >= contextWindowTokens * 0.8 &&
+    opts.messages.filter(m => m.role !== 'system').length > 1
+  ) {
+    const conversation = useChatStore.getState().conversations.find(c => c.id === opts.id);
+    messagesForFirstAttempt = await contextCompactionService.compact({
+      conversationId: opts.id,
+      systemPrompt: opts.prompt,
+      allMessages: opts.messages,
+      previousSummary: conversation?.compactionSummary,
+    }).catch(() => opts.messages);
+    if (!generationSession.isGeneratingFor(opts.id)) return true;
+  }
   let turnInterrupted = false; // PER-TURN stop truth from the loop outcome (returned to the caller)
   try {
-    const outcome = await gen(opts.messages);
+    const outcome = await gen(messagesForFirstAttempt);
     turnInterrupted = !!(outcome as { interrupted?: boolean } | void)
       ?.interrupted;
   } catch (error: any) {
@@ -554,12 +574,12 @@ async function generateWithCompactionRetry(
       .compact({
         conversationId: opts.id,
         systemPrompt: opts.prompt,
-        allMessages: opts.messages,
+        allMessages: messagesForFirstAttempt,
         previousSummary,
       })
       .catch(async () => {
         await llmService.clearKVCache(true).catch(() => {});
-        const recent = opts.messages
+        const recent = messagesForFirstAttempt
           .filter(m => m.role !== 'system')
           .slice(-FALLBACK_RECENT_MESSAGE_COUNT);
         return [

--- a/src/screens/ChatScreen/useChatGenerationActions.ts
+++ b/src/screens/ChatScreen/useChatGenerationActions.ts
@@ -478,13 +478,11 @@ async function prepareContext(
         ? server?.textContextWindowTokens
         : undefined) ?? model?.capabilities.maxContextLength;
     setDebugInfo(null);
-    return contextWindowTokens && contextWindowTokens > 0
-      ? {
-          contextPromptTokens: estimatedPromptTokens,
-          contextWindowTokens,
-          contextEstimate: true,
-        }
-      : undefined;
+    return {
+      contextPromptTokens: estimatedPromptTokens,
+      ...(contextWindowTokens && contextWindowTokens > 0 ? { contextWindowTokens } : {}),
+      contextEstimate: true,
+    };
   }
   try {
     const contextDebug = await llmService.getContextDebugInfo(messages);

--- a/src/screens/ChatScreen/useChatScreen.ts
+++ b/src/screens/ChatScreen/useChatScreen.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState, useCallback } from 'react';
+import { useMemo, useRef, useState, useCallback, useEffect } from 'react';
 import {
   NavigationProp,
   useNavigation,
@@ -142,6 +142,10 @@ export const useChatScreen = () => {
     setActiveConversation,
     setConversationProject,
   } = useChatStore();
+
+  useEffect(() => {
+    setDebugInfo(null);
+  }, [activeConversationId]);
 
   const { projects, getProject } = useProjectStore();
 

--- a/src/screens/RemoteServerEditorScreen.tsx
+++ b/src/screens/RemoteServerEditorScreen.tsx
@@ -133,12 +133,28 @@ export const RemoteServerEditorScreen: React.FC = () => {
           label="Text model"
           value={form.textModelId}
           options={form.discoveredModels}
-          onChange={form.setTextModelId}
+          onChange={id => {
+            if (id !== form.textModelId) form.setTextContextWindowTokens('');
+            form.setTextModelId(id);
+          }}
           placeholder="llama3.2"
           testID="server-text-model"
           loading={form.isTesting}
           allowManualEntry={form.modelManagement !== 'offgrid-desktop-v1'}
         />
+        <Text style={styles.label}>Text context window (tokens, optional)</Text>
+        <TextInput
+          testID="server-text-context-window"
+          style={[styles.input, form.errors.textContextWindowTokens && styles.inputError]}
+          value={form.textContextWindowTokens}
+          onChangeText={form.setTextContextWindowTokens}
+          placeholder="e.g., 131072"
+          placeholderTextColor={theme.colors.textMuted}
+          keyboardType="number-pad"
+        />
+        {form.errors.textContextWindowTokens ? (
+          <Text style={styles.errorText}>{form.errors.textContextWindowTokens}</Text>
+        ) : null}
         <RemoteModelField
           label="Image model"
           value={form.imageModelId}

--- a/src/screens/RemoteServerEditorScreen.tsx
+++ b/src/screens/RemoteServerEditorScreen.tsx
@@ -142,19 +142,6 @@ export const RemoteServerEditorScreen: React.FC = () => {
           loading={form.isTesting}
           allowManualEntry={form.modelManagement !== 'offgrid-desktop-v1'}
         />
-        <Text style={styles.label}>Text context window (tokens, optional)</Text>
-        <TextInput
-          testID="server-text-context-window"
-          style={[styles.input, form.errors.textContextWindowTokens && styles.inputError]}
-          value={form.textContextWindowTokens}
-          onChangeText={form.setTextContextWindowTokens}
-          placeholder="e.g., 131072"
-          placeholderTextColor={theme.colors.textMuted}
-          keyboardType="number-pad"
-        />
-        {form.errors.textContextWindowTokens ? (
-          <Text style={styles.errorText}>{form.errors.textContextWindowTokens}</Text>
-        ) : null}
         <RemoteModelField
           label="Image model"
           value={form.imageModelId}

--- a/src/services/contextCompaction.ts
+++ b/src/services/contextCompaction.ts
@@ -111,9 +111,8 @@ class ContextCompactionService {
           recentMessages.unshift(msg);
           recentTokensUsed += tokens;
         } else if (recentMessages.length === 0) {
-          // Last message is too large — truncate to fit
-          const charBudget = recentTokenBudget * CHARS_PER_TOKEN_ESTIMATE;
-          recentMessages.unshift({ ...msg, content: msg.content.slice(-charBudget) });
+          // Keep the active turn intact, even if it alone exceeds the budget.
+          recentMessages.unshift(msg);
           break;
         } else {
           break;
@@ -144,8 +143,14 @@ class ContextCompactionService {
       const cutoffMessageId = oldMessages[oldMessages.length - 1]?.id;
 
       // Persist compaction state
-      if (summary && cutoffMessageId) {
-        useChatStore.getState().updateCompactionState(conversationId, summary, cutoffMessageId);
+      if (summary && cutoffMessageId && cutoffMessageId !== 'compaction-summary') {
+        const chat = useChatStore.getState();
+        chat.updateCompactionState(conversationId, summary, cutoffMessageId);
+        chat.addMessage(conversationId, {
+          role: 'assistant',
+          content: 'Compacted',
+          isSystemInfo: true,
+        });
       }
 
       // Build result

--- a/src/services/contextCompaction.ts
+++ b/src/services/contextCompaction.ts
@@ -16,6 +16,10 @@
 import { llmService } from './llm';
 import { CONTEXT_PROMPT_BUDGET_RATIO } from './llmHelpers';
 import { useChatStore } from '../stores/chatStore';
+import { useAppStore } from '../stores/appStore';
+import { useRemoteServerStore } from '../stores/remoteServerStore';
+import { providerRegistry } from './providers/registry';
+import { APP_CONFIG } from '../constants';
 import { Message } from '../types';
 import logger from '../utils/logger';
 
@@ -93,12 +97,14 @@ class ContextCompactionService {
     try {
       await llmService.clearKVCache(true);
 
-      const ctxLength = llmService.getPerformanceSettings().contextLength || 2048;
+      const ctxLength = useRemoteServerStore.getState().activeServerId
+        ? useAppStore.getState().settings.contextLength || APP_CONFIG.maxContextLength
+        : llmService.getPerformanceSettings().contextLength || 2048;
       const summaryTokenBudget = Math.floor(ctxLength * SUMMARY_BUDGET_RATIO);
       const systemTokens = await this.countTokens(systemPrompt);
       const recentTokenBudget = Math.max(0, Math.floor(ctxLength * CONTEXT_PROMPT_BUDGET_RATIO) - summaryTokenBudget - systemTokens);
 
-      const nonSystem = allMessages.filter(m => m.role !== 'system');
+      const nonSystem = allMessages.filter(m => m.role !== 'system' && m.id !== 'compaction-summary');
       logger.log(`[ContextCompaction] ${nonSystem.length} messages, ctx=${ctxLength}, summaryBudget=${summaryTokenBudget}, recentBudget=${recentTokenBudget}`);
 
       // Walk backwards — keep recent messages that fit in the recent budget
@@ -127,6 +133,10 @@ class ContextCompactionService {
         logger.log('[ContextCompaction] No old messages to summarize');
         return [
           { id: 'system', role: 'system', content: systemPrompt, timestamp: 0 },
+          ...(previousSummary ? [{
+            id: 'compaction-summary', role: 'assistant' as const,
+            content: `[Previous conversation summary]\n${previousSummary}`, timestamp: 0,
+          }] : []),
           ...recentMessages,
         ];
       }
@@ -158,11 +168,11 @@ class ContextCompactionService {
         { id: 'system', role: 'system', content: systemPrompt, timestamp: 0 },
       ];
 
-      if (summary) {
+      if (summary || previousSummary) {
         result.push({
           id: 'compaction-summary',
           role: 'assistant',
-          content: `[Previous conversation summary]\n${summary}`,
+          content: `[Previous conversation summary]\n${summary || previousSummary}`,
           timestamp: 0,
         });
       }
@@ -191,7 +201,10 @@ class ContextCompactionService {
       : '';
 
     // Cap transcript to fit within context alongside the summarize instruction
-    const ctxLength = llmService.getPerformanceSettings().contextLength || 2048;
+    const remoteServerId = useRemoteServerStore.getState().activeServerId;
+    const ctxLength = remoteServerId
+      ? useAppStore.getState().settings.contextLength || APP_CONFIG.maxContextLength
+      : llmService.getPerformanceSettings().contextLength || 2048;
     const instructionOverhead = SUMMARIZER_INSTRUCTION_OVERHEAD_TOKENS;
     const inputBudget = ctxLength - summaryTokenBudget - instructionOverhead;
     const inputCharBudget = inputBudget * CHARS_PER_TOKEN_ESTIMATE;
@@ -216,6 +229,23 @@ class ContextCompactionService {
       },
     ];
 
+    if (remoteServerId) {
+      const provider = providerRegistry.getProvider(remoteServerId);
+      if (!provider) throw new Error('Remote model unavailable for compaction');
+      let summary = '';
+      let failure: Error | undefined;
+      await provider.generate(summaryMessages, {
+        maxTokens: summaryTokenBudget,
+        temperature: 0.2,
+        enableThinking: false,
+      }, {
+        onToken: token => { summary += token; },
+        onComplete: result => { summary = result.content || summary; },
+        onError: error => { failure = error; },
+      });
+      if (failure) throw failure;
+      return summary.trim().slice(0, summaryTokenBudget * CHARS_PER_TOKEN_ESTIMATE);
+    }
     return await llmService.generateWithMaxTokens(summaryMessages, summaryTokenBudget);
   }
 

--- a/src/services/generationRemoteHelpers.ts
+++ b/src/services/generationRemoteHelpers.ts
@@ -23,6 +23,7 @@ export async function generateRemoteResponseImpl(
 ): Promise<void> {
   const { conversationId, messages, onFirstToken } = req;
   if (!(await prepareGenerationImpl(svc, conversationId))) return;
+  svc.contextUsage = req.contextUsage;
   const chatStore = useChatStore.getState();
   const provider = svc.getCurrentProvider();
 
@@ -120,6 +121,7 @@ export async function generateRemoteWithToolsImpl(
   req: GenerationWithToolsRequest,
 ): Promise<void> {
   const { conversationId, messages, options } = req;
+  const { enabledToolIds, projectId, contextUsage, ...callbacks } = options;
   logger.log(
     `[GenService][DEBUG] generateRemoteWithToolsImpl — conv=${conversationId}, messages=${
       messages.length
@@ -131,6 +133,7 @@ export async function generateRemoteWithToolsImpl(
     );
     return;
   }
+  svc.contextUsage = contextUsage;
   const provider = svc.getCurrentProvider();
 
   if (!provider) {
@@ -142,8 +145,6 @@ export async function generateRemoteWithToolsImpl(
       provider.type
     }, capabilities=${JSON.stringify(provider.capabilities)}`,
   );
-
-  const { enabledToolIds, projectId, ...callbacks } = options;
 
   try {
     // Use the same tool loop but with remote provider

--- a/src/services/generationService.ts
+++ b/src/services/generationService.ts
@@ -14,6 +14,7 @@ import {
   buildToolLoopHandlersImpl,
   prepareGenerationImpl,
   generateResponseImpl,
+  type GenerationRequest,
   type GenerationWithToolsRequest,
 } from './generationServiceHelpers';
 import {
@@ -62,6 +63,7 @@ class GenerationService {
   private queueProcessor: QueueProcessor | null = null;
   private currentRemoteAbortController: AbortController | null = null;
   private remoteTimeToFirstToken: number | undefined;
+  private contextUsage: Pick<GenerationMeta, 'contextPromptTokens' | 'contextWindowTokens' | 'contextEstimate'> | undefined;
 
   // Token batching — collect tokens and flush to UI at a controlled rate
   private tokenBuffer: string = '';
@@ -146,17 +148,20 @@ class GenerationService {
   }
 
   /** Generate a response for a conversation. Runs independently of UI lifecycle. */
+  // Keep the existing positional callback argument for callers outside ChatScreen.
+  // eslint-disable-next-line max-params
   async generateResponse(
     conversationId: string,
     messages: Message[],
     onFirstToken?: () => void,
+    contextUsage?: GenerationRequest['contextUsage'],
   ): Promise<void> {
     logger.log(`[REMOTE-SM] generateResponse entry conv=${conversationId} msgs=${messages.length}`);
     // Route to remote provider if active
     if (this.isUsingRemoteProvider()) {
-      return this.generateRemoteResponse(conversationId, messages, onFirstToken);
+      return this.generateRemoteResponse(conversationId, messages, onFirstToken, contextUsage);
     }
-    return generateResponseImpl(this, { conversationId, messages, onFirstToken });
+    return generateResponseImpl(this, { conversationId, messages, onFirstToken, contextUsage });
   }
 
   /** Generate a response with tool calling support (LLM → tools → repeat, max 5 iterations). */
@@ -169,6 +174,7 @@ class GenerationService {
       onToolCallStart?: (name: string, args: Record<string, any>) => void;
       onToolCallComplete?: (name: string, result: ToolResult) => void;
       onFirstToken?: () => void;
+      contextUsage?: GenerationRequest['contextUsage'];
     },
   ): Promise<import('./generationToolLoop').ToolLoopOutcome | void> {
     // Route to remote provider if active
@@ -176,8 +182,9 @@ class GenerationService {
       return this.generateRemoteWithTools(conversationId, messages, options);
     }
     // Local generation with tools
-    const { enabledToolIds, projectId, ...callbacks } = options;
+    const { enabledToolIds, projectId, contextUsage, ...callbacks } = options;
     if (!(await this.prepareGeneration(conversationId))) return;
+    this.contextUsage = contextUsage;
 
     try {
       const outcome = await runToolLoop({
@@ -297,12 +304,14 @@ class GenerationService {
   }
 
   /** Generate a response using a remote provider */
+  // eslint-disable-next-line max-params
   async generateRemoteResponse(
     conversationId: string,
     messages: Message[],
     onFirstToken?: () => void,
+    contextUsage?: GenerationRequest['contextUsage'],
   ): Promise<void> {
-    return generateRemoteResponseImpl(this, { conversationId, messages, onFirstToken });
+    return generateRemoteResponseImpl(this, { conversationId, messages, onFirstToken, contextUsage });
   }
 
   /** Generate a response with tools using a remote provider */
@@ -366,6 +375,7 @@ class GenerationService {
     this.reasoningBuffer = '';
     this.totalReasoningLength = 0;
     this.remoteTimeToFirstToken = undefined;
+    this.contextUsage = undefined;
     this.updateState({
       isGenerating: false,
       isThinking: false,

--- a/src/services/generationServiceHelpers.ts
+++ b/src/services/generationServiceHelpers.ts
@@ -50,6 +50,7 @@ export interface GenerationRequest {
   conversationId: string;
   messages: Message[];
   onFirstToken?: () => void;
+  contextUsage?: Pick<GenerationMeta, 'contextPromptTokens' | 'contextWindowTokens' | 'contextEstimate'>;
 }
 
 export interface GenerationWithToolsRequest {
@@ -61,6 +62,7 @@ export interface GenerationWithToolsRequest {
     onToolCallStart?: (name: string, args: Record<string, any>) => void;
     onToolCallComplete?: (name: string, result: ToolResult) => void;
     onFirstToken?: () => void;
+    contextUsage?: GenerationRequest['contextUsage'];
   };
 }
 
@@ -103,6 +105,7 @@ function buildLiteRTMeta(
 
 export function buildGenerationMetaImpl(svc: any): GenerationMeta {
   const meta = buildBaseGenerationMeta(svc);
+  if (svc.contextUsage) Object.assign(meta, svc.contextUsage);
   const routed = svc.state?.routedToolNames;
   if (Array.isArray(routed) && routed.length > 0) meta.routedToolNames = routed;
   return meta;
@@ -418,6 +421,7 @@ export async function generateResponseImpl(
 ): Promise<void> {
   const { conversationId, messages, onFirstToken } = req;
   if (!(await prepareGenerationImpl(svc, conversationId))) return;
+  svc.contextUsage = req.contextUsage;
 
   if (isLiteRTActive()) {
     return runLiteRTResponseImpl(svc, req);

--- a/src/services/liteRTCompaction.ts
+++ b/src/services/liteRTCompaction.ts
@@ -1,4 +1,5 @@
 import { contextCompactionService } from './contextCompaction';
+import { useChatStore } from '../stores/chatStore';
 
 type Turn = { role: 'user' | 'assistant'; content: string };
 type SamplerConfigOpts = { temperature?: number; topK?: number; topP?: number };
@@ -116,6 +117,15 @@ export async function runCompaction(params: {
       : recentHistory;
 
     await resetFn(systemPrompt, { samplerConfig: opts.samplerConfig, tools: opts.tools, history: compactedHistory });
+    const previousChars = history.reduce((total, turn) => total + turn.content.length, 0);
+    const compactedChars = compactedHistory.reduce((total, turn) => total + turn.content.length, 0);
+    if (recentStart > 0 && compactedChars < previousChars) {
+      useChatStore.getState().addMessage(conversationId, {
+        role: 'assistant',
+        content: 'Compacted',
+        isSystemInfo: true,
+      });
+    }
   } finally {
     contextCompactionService.signalCompacting(false);
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -238,6 +238,10 @@ export interface GenerationMeta {
   timeToFirstToken?: number;
   /** Token count (text generation only) */
   tokenCount?: number;
+  contextPromptTokens?: number;
+  contextWindowTokens?: number;
+  /** Prompt count is estimated rather than provider-reported. */
+  contextEstimate?: boolean;
   /** Model load/init time in seconds */
   modelLoadTimeSeconds?: number;
   /** Image generation steps */

--- a/src/types/remoteServer.ts
+++ b/src/types/remoteServer.ts
@@ -59,6 +59,8 @@ export interface RemoteServer {
   notes?: string;
   /** Selected model IDs for each OpenAI-compatible endpoint. */
   mediaModels?: RemoteMediaModelIds;
+  /** Context window for the selected remote text model, if set by the user. */
+  textContextWindowTokens?: number;
   /** Available models reported by servers that declare a model kind. */
   modelCatalog?: RemoteModelCatalog;
   /** A detected model-management contract. Generic OpenAI-compatible servers leave this unset. */


### PR DESCRIPTION
## Summary
- Keep the active Mobile turn intact during context compaction and mark completed compaction.
- Save context use with each reply for local and remote text models.
- Use a reported remote context window or a saved limit. Show estimated prompt tokens when the limit is unknown.

## Checks
- Mobile TypeScript check and focused lint passed.
- No Mobile E2E or live device verification was run, as requested.
- Unrelated working-tree files are not in this PR.