### PR TITLE
fix(chat): carry Thinking controls to remote models

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+set -e
+PATH="$(git rev-parse --show-toplevel)/node_modules/.bin:$PATH"
+export PATH
 
 ZERO_OID="0000000000000000000000000000000000000000"
 

--- a/__tests__/integration/generation/remoteOpenRouterReasoning.rendered.test.tsx
+++ b/__tests__/integration/generation/remoteOpenRouterReasoning.rendered.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { RemoteServerEditorScreen } from '../../../src/screens/RemoteServerEditorScreen';
+import { RemoteServersScreen } from '../../../src/screens/RemoteServersScreen';
+import { ChatScreen } from '../../../src/screens/ChatScreen';
+import { ThinkingBudgetSelector } from '../../../src/components/settings/textGenAdvancedSections';
+
+jest.unmock('@react-navigation/native');
+
+const Stack = createNativeStackNavigator();
+
+function installOpenRouterBoundary(): () => void {
+  const oldFetch = global.fetch;
+  const oldXHR = global.XMLHttpRequest;
+  const response = (body: unknown): Response => ({
+    ok: true, status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  }) as Response;
+
+  global.fetch = (async (input: RequestInfo | URL) => {
+    if (String(input).endsWith('/v1/models')) {
+      return response({
+        data: [{
+          id: 'qwen/qwen3-8b', name: 'Qwen3 8B',
+          context_length: 131072,
+          reasoning: { mandatory: false },
+          supported_parameters: ['reasoning', 'tools'],
+          architecture: { input_modalities: ['text'] },
+        }],
+      });
+    }
+    return { ...response({}), ok: false, status: 404 } as Response;
+  }) as typeof global.fetch;
+
+  class ServerStream {
+    responseText = '';
+    responseURL = '';
+    readyState = 0;
+    status = 0;
+    onprogress: (() => void) | null = null;
+    onreadystatechange: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    ontimeout: (() => void) | null = null;
+    open(_method: string, url: string): void { this.responseURL = url; }
+    setRequestHeader(): void {}
+    abort(): void {}
+    send(body: string): void {
+      const request = JSON.parse(body) as { reasoning?: { max_tokens?: number; effort?: string } };
+      const label = request.reasoning?.max_tokens === 1024
+        ? 'budget 1024'
+        : request.reasoning?.effort === 'none' ? 'Thinking off' : 'unexpected reasoning setting';
+      const frames = [
+        ...(request.reasoning?.max_tokens === 1024
+          ? [{ choices: [{ delta: { reasoning: 'The server reasoned.' } }] }]
+          : []),
+        { choices: [{ delta: { content: `Server received ${label}.` } }] },
+      ];
+      setTimeout(() => {
+        const serializedFrames = frames.map(frame => `data: ${JSON.stringify(frame)}\n\n`).join('');
+        this.responseText = `${serializedFrames}data: [DONE]\n\n`;
+        this.onprogress?.();
+        this.readyState = 4;
+        this.status = 200;
+        this.onreadystatechange?.();
+      }, 0);
+    }
+  }
+  global.XMLHttpRequest = ServerStream as unknown as typeof XMLHttpRequest;
+  return () => {
+    global.fetch = oldFetch;
+    global.XMLHttpRequest = oldXHR;
+  };
+}
+
+function renderRoute(name: 'RemoteServers' | 'Chat') {
+  return render(
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName={name}>
+        <Stack.Screen name="RemoteServers" component={RemoteServersScreen} />
+        <Stack.Screen name="RemoteServerEditor" component={RemoteServerEditorScreen} />
+        <Stack.Screen name="Chat" component={ChatScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>,
+  );
+}
+
+it('uses the existing Thinking toggle and budget for an OpenRouter chat', async () => {
+  const restoreServer = installOpenRouterBoundary();
+  try {
+    const editor = renderRoute('RemoteServers');
+    fireEvent.press(editor.getByTestId('add-server'));
+    fireEvent.changeText(await waitFor(() => editor.getByTestId('server-name')), 'OpenRouter');
+    fireEvent.changeText(editor.getByTestId('server-endpoint'), 'https://openrouter.ai/api');
+    fireEvent.press(editor.getByTestId('test-connection'));
+    await waitFor(() => expect(editor.queryByText(/Connected \(/)).not.toBeNull());
+    fireEvent.press(editor.getByTestId('save-server'));
+    fireEvent.press(await waitFor(() => editor.getByText('Continue')));
+    await waitFor(() => expect(editor.queryByTestId('server-name')).toBeNull());
+    editor.unmount();
+
+    const budget = render(<ThinkingBudgetSelector />);
+    fireEvent.press(budget.getByTestId('thinking-budget-1024-button'));
+    budget.unmount();
+
+    const chat = renderRoute('Chat');
+    fireEvent.press(await waitFor(() => chat.getByText('Select Model')));
+    fireEvent.press(await waitFor(() => chat.getByText('Qwen3 8B')));
+    fireEvent.press(await waitFor(() => chat.getByTestId('quick-settings-button')));
+    fireEvent.press(await waitFor(() => chat.getByTestId('quick-thinking-toggle')));
+    fireEvent.changeText(chat.getByTestId('chat-input'), 'First turn');
+    fireEvent.press(chat.getByTestId('send-button'));
+    await waitFor(() => expect(chat.queryByText('Server received budget 1024.')).not.toBeNull());
+
+    fireEvent.press(chat.getByTestId('quick-settings-button'));
+    fireEvent.press(await waitFor(() => chat.getByTestId('quick-thinking-toggle')));
+    fireEvent.changeText(chat.getByTestId('chat-input'), 'Second turn');
+    fireEvent.press(chat.getByTestId('send-button'));
+    await waitFor(() => expect(chat.queryByText('Server received Thinking off.')).not.toBeNull());
+    chat.unmount();
+  } finally {
+    restoreServer();
+  }
+}, 20_000);

--- a/__tests__/integration/generation/remoteReasoningControls.rendered.test.tsx
+++ b/__tests__/integration/generation/remoteReasoningControls.rendered.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { RemoteServerEditorScreen } from '../../../src/screens/RemoteServerEditorScreen';
+import { RemoteServersScreen } from '../../../src/screens/RemoteServersScreen';
+import { ChatScreen } from '../../../src/screens/ChatScreen';
+
+// Use the real navigator. The Jest setup replaces only native screen views.
+jest.unmock('@react-navigation/native');
+
+const Stack = createNativeStackNavigator();
+const MODELS = [
+  { id: 'boolean-model', name: 'Boolean Model', object: 'model' },
+];
+
+/** The LAN server and its native stream are the only test-owned boundaries. */
+function installServerBoundary(): () => void {
+  const oldFetch = global.fetch;
+  const oldXHR = global.XMLHttpRequest;
+  const response = (body: unknown, ok = true): Response => ({
+    ok, status: ok ? 200 : 404,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  }) as Response;
+
+  global.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.endsWith('/v1/models')) return response({ object: 'list', data: MODELS });
+    if (url.endsWith('/api/show')) {
+      return response({
+        capabilities: ['thinking'],
+        model_info: { 'llama.context_length': 8192 },
+        template: '{{ if .Think }} reasoning {{ end }}',
+      });
+    }
+    return response({}, false);
+  }) as typeof global.fetch;
+
+  class ServerStream {
+    responseText = '';
+    responseURL = '';
+    readyState = 0;
+    status = 0;
+    onprogress: (() => void) | null = null;
+    onreadystatechange: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    ontimeout: (() => void) | null = null;
+    open(_method: string, url: string): void { this.responseURL = url; }
+    setRequestHeader(): void {}
+    abort(): void {}
+    send(body: string): void {
+      const request = JSON.parse(body) as { think?: boolean | string };
+      const mode = request.think === true ? 'on' : request.think === false ? 'off' : request.think;
+      const lines = [
+        ...(request.think === false ? [] : [{ message: { thinking: 'The server reasoned.' } }]),
+        { message: { content: `Server received Thinking ${mode}.` } },
+        { message: { content: '' }, done: true },
+      ];
+      setTimeout(() => {
+        this.responseText = `${lines.map(line => JSON.stringify(line)).join('\n')}\n`;
+        this.onprogress?.();
+        this.readyState = 4;
+        this.status = 200;
+        this.onreadystatechange?.();
+      }, 0);
+    }
+  }
+  global.XMLHttpRequest = ServerStream as unknown as typeof XMLHttpRequest;
+  return () => {
+    global.fetch = oldFetch;
+    global.XMLHttpRequest = oldXHR;
+  };
+}
+
+function renderRoute(name: 'RemoteServers' | 'Chat') {
+  return render(
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName={name}>
+        <Stack.Screen name="RemoteServers" component={RemoteServersScreen} />
+        <Stack.Screen name="RemoteServerEditor" component={RemoteServerEditorScreen} />
+        <Stack.Screen name="Chat" component={ChatScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>,
+  );
+}
+
+describe('remote reasoning controls through the Mobile chat UI', () => {
+  it('uses the same Thinking toggle to start and stop reasoning on a remote model', async () => {
+    const restoreServer = installServerBoundary();
+    try {
+      const editor = renderRoute('RemoteServers');
+      fireEvent.press(editor.getByTestId('add-server'));
+      await waitFor(() => expect(editor.queryByTestId('server-name')).not.toBeNull());
+      fireEvent.changeText(editor.getByTestId('server-name'), 'Ollama');
+      fireEvent.changeText(editor.getByTestId('server-endpoint'), 'http://localhost:11434');
+      fireEvent.press(editor.getByTestId('test-connection'));
+      await waitFor(() => expect(editor.queryByText(/Connected \(/)).not.toBeNull());
+      fireEvent.press(editor.getByTestId('save-server'));
+      await waitFor(() => expect(editor.queryByTestId('server-name')).toBeNull());
+      editor.unmount();
+
+      const chat = renderRoute('Chat');
+      fireEvent.press(await waitFor(() => chat.getByText('Select Model')));
+      fireEvent.press(await waitFor(() => chat.getByText('Boolean Model')));
+      fireEvent.press(await waitFor(() => chat.getByTestId('quick-settings-button')));
+      const thinking = await waitFor(() => chat.getByTestId('quick-thinking-toggle'));
+      fireEvent.press(thinking);
+      fireEvent.changeText(chat.getByTestId('chat-input'), 'First turn');
+      fireEvent.press(chat.getByTestId('send-button'));
+      await waitFor(() => expect(chat.queryByText(/Server received Thinking on/)).not.toBeNull());
+
+      fireEvent.press(chat.getByTestId('quick-settings-button'));
+      fireEvent.press(await waitFor(() => chat.getByTestId('quick-thinking-toggle')));
+      fireEvent.changeText(chat.getByTestId('chat-input'), 'Second turn');
+      fireEvent.press(chat.getByTestId('send-button'));
+      await waitFor(() => expect(chat.queryByText(/Server received Thinking off/)).not.toBeNull());
+      await waitFor(() => expect(chat.queryByTestId('stop-button')).toBeNull());
+      chat.unmount();
+    } finally {
+      restoreServer();
+    }
+  }, 20_000);
+});

--- a/__tests__/integration/generation/remoteReasoningLevels.rendered.test.tsx
+++ b/__tests__/integration/generation/remoteReasoningLevels.rendered.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { RemoteServersScreen } from '../../../src/screens/RemoteServersScreen';
+import { RemoteServerEditorScreen } from '../../../src/screens/RemoteServerEditorScreen';
+import { ChatScreen } from '../../../src/screens/ChatScreen';
+import { ThinkingBudgetSelector } from '../../../src/components/settings/textGenAdvancedSections';
+
+jest.unmock('@react-navigation/native');
+
+const Stack = createNativeStackNavigator();
+
+function installServerBoundary(): () => void {
+  const oldFetch = global.fetch;
+  const oldXHR = global.XMLHttpRequest;
+  const response = (body: unknown, ok = true): Response => ({
+    ok, status: ok ? 200 : 404,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  }) as Response;
+  global.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.endsWith('/v1/models')) {
+      return response({ object: 'list', data: [{ id: 'levels-model', name: 'Level Model', object: 'model' }] });
+    }
+    if (url.endsWith('/api/show')) {
+      return response({
+        capabilities: ['thinking'],
+        details: { family: 'gptoss' },
+        model_info: { 'gptoss.context_length': 8192 },
+        template: '{{ if and .IsThinkSet .Think (ne .ThinkLevel "") }}Reasoning: {{ .ThinkLevel }}{{ else }}Reasoning: medium{{ end }}',
+      });
+    }
+    return response({}, false);
+  }) as typeof global.fetch;
+
+  class ServerStream {
+    responseText = '';
+    responseURL = '';
+    readyState = 0;
+    status = 0;
+    onprogress: (() => void) | null = null;
+    onreadystatechange: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    ontimeout: (() => void) | null = null;
+    open(_method: string, url: string): void { this.responseURL = url; }
+    setRequestHeader(): void {}
+    abort(): void {}
+    send(body: string): void {
+      const request = JSON.parse(body) as { think?: string };
+      const lines = [
+        { message: { thinking: 'The server reasoned.' } },
+        { message: { content: `Server received Thinking ${request.think}.` } },
+        { message: { content: '' }, done: true },
+      ];
+      setTimeout(() => {
+        this.responseText = `${lines.map(line => JSON.stringify(line)).join('\n')}\n`;
+        this.onprogress?.();
+        this.readyState = 4;
+        this.status = 200;
+        this.onreadystatechange?.();
+      }, 0);
+    }
+  }
+  global.XMLHttpRequest = ServerStream as unknown as typeof XMLHttpRequest;
+  return () => {
+    global.fetch = oldFetch;
+    global.XMLHttpRequest = oldXHR;
+  };
+}
+
+function renderRoute(name: 'RemoteServers' | 'Chat') {
+  return render(
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName={name}>
+        <Stack.Screen name="RemoteServers" component={RemoteServersScreen} />
+        <Stack.Screen name="RemoteServerEditor" component={RemoteServerEditorScreen} />
+        <Stack.Screen name="Chat" component={ChatScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>,
+  );
+}
+
+it('uses the existing budget for an Ollama model that accepts reasoning levels', async () => {
+  const restoreServer = installServerBoundary();
+  try {
+    const editor = renderRoute('RemoteServers');
+    fireEvent.press(editor.getByTestId('add-server'));
+    fireEvent.changeText(await waitFor(() => editor.getByTestId('server-name')), 'Ollama');
+    fireEvent.changeText(editor.getByTestId('server-endpoint'), 'http://localhost:11434');
+    fireEvent.press(editor.getByTestId('test-connection'));
+    await waitFor(() => expect(editor.queryByText(/Connected \(/)).not.toBeNull());
+    fireEvent.press(editor.getByTestId('save-server'));
+    await waitFor(() => expect(editor.queryByTestId('server-name')).toBeNull());
+    editor.unmount();
+
+    const budget = render(<ThinkingBudgetSelector />);
+    fireEvent.press(budget.getByTestId('thinking-budget-8192-button'));
+    budget.unmount();
+
+    const chat = renderRoute('Chat');
+    fireEvent.press(await waitFor(() => chat.getByText('Select Model')));
+    fireEvent.press(await waitFor(() => chat.getByText('Level Model')));
+    fireEvent.changeText(await waitFor(() => chat.getByTestId('chat-input')), 'Answer with reasoning');
+    fireEvent.press(await waitFor(() => chat.getByTestId('send-button')));
+    await waitFor(() => expect(chat.queryByText(/Server received Thinking high/)).not.toBeNull());
+    fireEvent.press(chat.getByTestId('quick-settings-button'));
+    await waitFor(() => expect(chat.queryByTestId('quick-thinking-toggle')).toBeNull());
+    chat.unmount();
+  } finally {
+    restoreServer();
+  }
+}, 20_000);

--- a/__tests__/integration/home/homeRestoredRemoteText.rendered.test.tsx
+++ b/__tests__/integration/home/homeRestoredRemoteText.rendered.test.tsx
@@ -1,0 +1,49 @@
+import { installNativeBoundary, requireRTL } from '../../harness/nativeBoundary';
+
+describe('Home with a saved remote Text selection', () => {
+  it('keeps Text active and New Chat available while discovery details reload', async () => {
+    installNativeBoundary();
+    const AsyncStorage = require('@react-native-async-storage/async-storage');
+    await AsyncStorage.clear();
+    await AsyncStorage.setItem('remote-servers', JSON.stringify({
+      state: {
+        servers: [{
+          id: 'gateway',
+          name: 'Off Grid AI Gateway',
+          endpoint: 'http://192.168.1.50:7878',
+          providerType: 'openai-compatible',
+          createdAt: '2026-09-12T00:00:00.000Z',
+          mediaModels: { text: 'qwen/qwen3-8b' },
+        }],
+        activeServerId: 'gateway',
+        activeRemoteTextModelId: 'qwen/qwen3-8b',
+        discoveredModels: {},
+      },
+      version: 2,
+    }));
+
+    const React = require('react');
+    const rtl = requireRTL();
+    const { useRemoteServerStore } = require('../../../src/stores');
+    await useRemoteServerStore.persist.rehydrate();
+    const { HomeScreen } = require('../../../src/screens/HomeScreen');
+    const navigation = {
+      navigate: () => {},
+      goBack: () => {},
+      setOptions: () => {},
+      addListener: () => () => {},
+    };
+
+    const home = rtl.render(React.createElement(HomeScreen, { navigation }));
+    await rtl.waitFor(() => {
+      expect(home.getByTestId('model-summary-text').props.accessibilityState.selected).toBe(true);
+      expect(home.getByTestId('new-chat-button')).toBeTruthy();
+    });
+
+    rtl.fireEvent.press(home.getByTestId('models-summary'));
+    expect(await home.findByText('qwen/qwen3-8b')).toBeTruthy();
+    rtl.fireEvent.press(home.getByTestId('models-row-text'));
+    expect(await home.findByTestId('currently-loaded-model')).toBeTruthy();
+    home.unmount();
+  });
+});

--- a/__tests__/rntl/components/GenerationSettingsModal.test.tsx
+++ b/__tests__/rntl/components/GenerationSettingsModal.test.tsx
@@ -663,7 +663,7 @@ describe('GenerationSettingsModal', () => {
     fireEvent.press(getByText('TEXT GENERATION'));
 
     expect(getByText('Show Generation Details')).toBeTruthy();
-    expect(getByText('Display GPU, model, tok/s, and image settings below each message')).toBeTruthy();
+    expect(getByText('Show context use, model, speed, and image settings below each reply')).toBeTruthy();
   });
 
   it('calls updateSettings to enable show generation details', () => {

--- a/__tests__/rntl/screens/ModelSettingsScreen.test.tsx
+++ b/__tests__/rntl/screens/ModelSettingsScreen.test.tsx
@@ -179,7 +179,7 @@ describe('ModelSettingsScreen', () => {
       expect(getByText('Show Generation Details')).toBeTruthy();
       expect(
         getByText(
-          'Display GPU, model, tok/s, and image settings below each message',
+          'Show context use, model, speed, and image settings below each reply',
         ),
       ).toBeTruthy();
     });

--- a/src/screens/ChatScreen/useChatModelActions.ts
+++ b/src/screens/ChatScreen/useChatModelActions.ts
@@ -382,7 +382,7 @@ type ModelStateSyncDeps = {
   activeModelId: string | null;
   activeModel: DownloadedModel | undefined;
   modelDeps: any;
-  activeRemoteModel: { capabilities?: { supportsVision?: boolean; supportsToolCalling?: boolean; supportsThinking?: boolean } } | null;
+  activeRemoteModel: { capabilities?: { supportsVision?: boolean; supportsToolCalling?: boolean; supportsThinking?: boolean; thinkingLevelsOnly?: boolean } } | null;
   activeRemoteTextModelId: string | null;
   isModelLoading: boolean;
   setSupportsVision: (v: boolean) => void;
@@ -429,5 +429,5 @@ export function useChatModelStateSync(deps: ModelStateSyncDeps): void {
     });
     setSupportsToolCalling(caps.tools);
     setSupportsThinking(caps.thinking);
-  }, [activeModelId, activeModel?.engine, isModelLoading, activeRemoteTextModelId, activeRemoteModel?.capabilities?.supportsToolCalling, activeRemoteModel?.capabilities?.supportsThinking]);
+  }, [activeModelId, activeModel?.engine, isModelLoading, activeRemoteTextModelId, activeRemoteModel?.capabilities?.supportsToolCalling, activeRemoteModel?.capabilities?.supportsThinking, activeRemoteModel?.capabilities?.thinkingLevelsOnly]);
 }

--- a/src/screens/HomeScreen/hooks/useHomeScreen.ts
+++ b/src/screens/HomeScreen/hooks/useHomeScreen.ts
@@ -133,7 +133,7 @@ export const useHomeScreen = (navigation: HomeScreenNavigationProp) => {
     [_handleSelectImageModel],
   );
 
-  const { model: activeTextModel, modelId: activeTextModelId } =
+  const { model: activeTextModel, modelId: activeTextModelId, modelName: activeTextModelName } =
     useActiveTextModel();
 
   const { runLANDiscovery } = useLANDiscovery({ navigation, setAlertState });
@@ -376,6 +376,8 @@ export const useHomeScreen = (navigation: HomeScreenNavigationProp) => {
     generatedImages,
     conversations,
     activeTextModel,
+    activeTextModelId,
+    activeTextModelName,
     activeImageModel,
     recentConversations,
     // Remote model state

--- a/src/screens/HomeScreen/index.tsx
+++ b/src/screens/HomeScreen/index.tsx
@@ -75,7 +75,8 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
     activeImageModelId,
     generatedImages,
     conversations,
-    activeTextModel,
+    activeTextModelId,
+    activeTextModelName,
     activeImageModel,
     recentConversations,
     // Remote model state
@@ -109,7 +110,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   const remoteLabels = useActiveRemoteModelLabels();
 
   const modelLabels = homeModelLabels({
-    text: activeTextModel?.name,
+    text: activeTextModelId ? activeTextModelName : undefined,
     image: activeImageModel?.name,
     voice: remoteLabels.voice,
     transcription: remoteLabels.transcription,
@@ -198,7 +199,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
           </AnimatedEntry>
 
           {/* New Chat Button */}
-          {activeTextModel || activeImageModelId ? (
+          {activeTextModelId || activeImageModelId ? (
             <Button
               title="New Chat"
               onPress={startNewChat}

--- a/src/services/engines.ts
+++ b/src/services/engines.ts
@@ -19,7 +19,7 @@ export interface EngineCapabilities {
 
 /** Runtime inputs for deriveEngineCapabilities — passed explicitly so the rule is pure/testable. */
 /** A remote model's declared capabilities (single named type so callers don't index CapabilityInputs). */
-export type RemoteCaps = { supportsVision?: boolean; supportsToolCalling?: boolean; supportsThinking?: boolean } | null;
+export type RemoteCaps = { supportsVision?: boolean; supportsToolCalling?: boolean; supportsThinking?: boolean; thinkingLevelsOnly?: boolean } | null;
 
 export interface CapabilityInputs {
   /** A remote (gateway) model is active — its declared capabilities win. */
@@ -51,7 +51,7 @@ export function deriveEngineCapabilities(i: CapabilityInputs): EngineCapabilitie
     return {
       vision: i.remoteCaps?.supportsVision ?? false,
       tools: i.remoteCaps?.supportsToolCalling ?? false,
-      thinking: i.remoteCaps?.supportsThinking ?? false,
+      thinking: !!i.remoteCaps?.supportsThinking && !i.remoteCaps?.thinkingLevelsOnly,
       audio: false, // remote audio capability is not tracked today
     };
   }

--- a/src/services/generationRemoteHelpers.ts
+++ b/src/services/generationRemoteHelpers.ts
@@ -39,7 +39,7 @@ export async function generateRemoteResponseImpl(
   // abortRequested is reset by the next generation's prepareGeneration().
   const { signal: generationSignal } = svc.currentRemoteAbortController;
 
-  const { temperature, maxTokens, topP, thinkingEnabled } =
+  const { temperature, maxTokens, topP, thinkingEnabled, reasoningBudget } =
     useAppStore.getState().settings;
   const options: GenerationOptions = {
     temperature,
@@ -47,6 +47,7 @@ export async function generateRemoteResponseImpl(
     topP,
     stopSequences: [],
     enableThinking: thinkingEnabled && provider.capabilities.supportsThinking,
+    reasoningBudget,
   };
 
   try {

--- a/src/services/generationToolLoop.ts
+++ b/src/services/generationToolLoop.ts
@@ -489,6 +489,7 @@ function remoteGenerateOnce(
     topP: settings.topP,
     tools,
     enableThinking: thinkingEnabled,
+    reasoningBudget: settings.reasoningBudget,
   };
   let _fullContent = '';
   let streamed = false;

--- a/src/services/providers/openAICompatibleProvider.ts
+++ b/src/services/providers/openAICompatibleProvider.ts
@@ -139,6 +139,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
           options, callbacks, signal,
           endpoint: this.config.endpoint,
           modelId: this.config.modelId,
+          thinkingLevelsOnly: this.modelCapabilities.thinkingLevelsOnly,
           abort: () => this.abortController?.abort(),
         });
       }

--- a/src/services/providers/openAICompatibleProvider.ts
+++ b/src/services/providers/openAICompatibleProvider.ts
@@ -6,7 +6,7 @@
  */
 
 import { Message } from '../../types';
-import { openRouterReasoningPayload, REASONING_BUDGET_AUTO } from '@offgrid/models';
+import { openRouterReasoningPayload, reasoningBudgetPayload, REASONING_BUDGET_AUTO } from '@offgrid/models';
 import type {
   LLMProvider,
   ProviderType,
@@ -111,6 +111,9 @@ export class OpenAICompatibleProvider implements LLMProvider {
       // discovered capability — not the endpoint's port — keeps the "which server
       // accepts this?" decision in one place and free of implementation coupling.
       ...(this.modelCapabilities.acceptsThinkingKwarg && { chat_template_kwargs: { enable_thinking: thinkingEnabled } }),
+      ...(this.config.modelId.startsWith('remote-vision:') && this.modelCapabilities.acceptsThinkingKwarg
+        ? reasoningBudgetPayload(thinkingEnabled, options.reasoningBudget ?? REASONING_BUDGET_AUTO)
+        : {}),
       ...(isOpenRouter && this.modelCapabilities.supportsThinking
         ? thinkingEnabled
           ? openRouterReasoningPayload(true, options.reasoningBudget ?? REASONING_BUDGET_AUTO)

--- a/src/services/providers/openAICompatibleProvider.ts
+++ b/src/services/providers/openAICompatibleProvider.ts
@@ -6,6 +6,7 @@
  */
 
 import { Message } from '../../types';
+import { openRouterReasoningPayload, REASONING_BUDGET_AUTO } from '@offgrid/models';
 import type {
   LLMProvider,
   ProviderType,
@@ -91,6 +92,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
     options: GenerationOptions,
     thinkingEnabled: boolean
   ): Record<string, unknown> {
+    const isOpenRouter = new URL(this.config.endpoint).hostname === 'openrouter.ai';
     return {
       model: this.config.modelId,
       messages: openaiMessages,
@@ -109,6 +111,11 @@ export class OpenAICompatibleProvider implements LLMProvider {
       // discovered capability — not the endpoint's port — keeps the "which server
       // accepts this?" decision in one place and free of implementation coupling.
       ...(this.modelCapabilities.acceptsThinkingKwarg && { chat_template_kwargs: { enable_thinking: thinkingEnabled } }),
+      ...(isOpenRouter && this.modelCapabilities.supportsThinking
+        ? thinkingEnabled
+          ? openRouterReasoningPayload(true, options.reasoningBudget ?? REASONING_BUDGET_AUTO)
+          : { reasoning: { effort: 'none' } }
+        : {}),
     };
   }
 

--- a/src/services/providers/openAICompatibleStream.ts
+++ b/src/services/providers/openAICompatibleStream.ts
@@ -271,6 +271,11 @@ export async function generateOllamaChatImpl(
 ): Promise<void> {
   const { options, callbacks, signal, endpoint, modelId, abort } = req;
   const thinkingEnabled = options.enableThinking !== false;
+  const think = req.thinkingLevelsOnly
+    ? !options.reasoningBudget ? 'medium'
+      : options.reasoningBudget <= 1024 ? 'low'
+        : options.reasoningBudget <= 4096 ? 'medium' : 'high'
+    : thinkingEnabled;
 
   // Convert to Ollama message format
   // Convert tool_calls arguments from JSON strings to objects for Ollama's native format
@@ -316,7 +321,7 @@ export async function generateOllamaChatImpl(
   });
 
   const requestBody: Record<string, unknown> = {
-    model: modelId, messages: ollamaMessages, stream: true, think: thinkingEnabled,
+    model: modelId, messages: ollamaMessages, stream: true, think,
     ...(options.tools && options.tools.length > 0 && { tools: options.tools }),
     options: {
       ...(options.temperature !== undefined && { temperature: options.temperature }),

--- a/src/services/providers/openAICompatibleTypes.ts
+++ b/src/services/providers/openAICompatibleTypes.ts
@@ -56,5 +56,6 @@ export interface OllamaChatRequest {
   signal: AbortSignal;
   endpoint: string;
   modelId: string;
+  thinkingLevelsOnly?: boolean;
   abort: () => void;
 }

--- a/src/services/providers/types.ts
+++ b/src/services/providers/types.ts
@@ -26,6 +26,8 @@ export interface ProviderCapabilities {
    * gates on this flag instead of sniffing the port.
    */
   acceptsThinkingKwarg?: boolean;
+  /** This model accepts thinking levels, but cannot turn thinking off. */
+  thinkingLevelsOnly?: boolean;
   /** Maximum context window length (if known) */
   maxContextLength?: number;
   /** Provider name for display */
@@ -76,6 +78,8 @@ export interface GenerationOptions {
   stopSequences?: string[];
   /** Whether to enable thinking/reasoning mode (Ollama: sends "think" param; others: parsed from response) */
   enableThinking?: boolean;
+  /** User's existing thinking budget; providers translate it when they support levels. */
+  reasoningBudget?: number;
 }
 
 /** Tool definition for function calling */
@@ -163,4 +167,3 @@ export interface LLMProvider {
   /** Clean up resources */
   dispose?(): Promise<void>;
 }
-

--- a/src/services/remoteServerManagerUtils.ts
+++ b/src/services/remoteServerManagerUtils.ts
@@ -173,6 +173,7 @@ export async function setActiveRemoteTextModelImpl(
         supportsVision: discoveredModel.capabilities.supportsVision,
         supportsToolCalling: discoveredModel.capabilities.supportsToolCalling,
         supportsThinking: discoveredModel.capabilities.supportsThinking,
+        thinkingLevelsOnly: discoveredModel.capabilities.thinkingLevelsOnly,
         acceptsThinkingKwarg: discoveredModel.capabilities.acceptsThinkingKwarg,
       });
       logger.log(

--- a/src/services/sync/messageContext.ts
+++ b/src/services/sync/messageContext.ts
@@ -49,6 +49,20 @@ export function serializeMessageContext(
     // Which tools this turn was GIVEN, not just the ones it called: a reply that had three tools and
     // used none is a different fact, and it is only known on the device that generated it.
     toolsOffered: message.generationMeta?.routedToolNames,
+    metrics: message.role === 'assistant' ? {
+      totalSeconds: message.generationTimeMs === undefined
+        ? undefined
+        : message.generationTimeMs / 1000,
+      timeToFirstTokenSeconds: message.generationMeta?.timeToFirstToken,
+      decodeTokensPerSecond:
+        message.generationMeta?.decodeTokensPerSecond ?? message.generationMeta?.tokensPerSecond,
+      prefillTokensPerSecond: message.generationMeta?.prefillTokensPerSecond,
+      completionTokens: message.generationMeta?.tokenCount,
+      contextWindowTokens: message.generationMeta?.contextWindowTokens,
+      ...(message.generationMeta?.contextEstimate === false
+        ? { promptTokens: message.generationMeta.contextPromptTokens }
+        : { estimatedPromptTokens: message.generationMeta?.contextPromptTokens }),
+    } : undefined,
     toolCalls: message.toolArtifacts?.filter(
       artifact => artifact.id !== RETRIEVAL_TOOL_ARTIFACT_ID,
     ),

--- a/src/stores/remoteModelCapabilities.ts
+++ b/src/stores/remoteModelCapabilities.ts
@@ -16,6 +16,7 @@ export interface RemoteModelInfo {
   supportsThinking?: boolean;
   /** Server honors chat_template_kwargs.enable_thinking to toggle reasoning per request. */
   acceptsThinkingKwarg?: boolean;
+  thinkingLevelsOnly?: boolean;
 }
 
 function parseModelInfoKeys(modelInfo: Record<string, unknown>): { contextLength: number; supportsVision: boolean } {
@@ -78,10 +79,15 @@ function extractOllamaCapabilities(data: Record<string, unknown>): RemoteModelIn
   const template = typeof data.template === 'string' ? data.template : '';
   const modelfile = typeof data.modelfile === 'string' ? data.modelfile : '';
   const supportsThinking =
+    (Array.isArray(data.capabilities) && data.capabilities.includes('thinking')) ||
     /\.Think|\.Thinking|\.IsThinkSet/.test(template) ||
     /^RENDERER\s/m.test(modelfile);
 
-  return { contextLength, supportsVision, supportsToolCalling, supportsThinking };
+  // The server reports the model architecture; gptoss ignores boolean think values.
+  const details = data.details as Record<string, unknown> | undefined;
+  const thinkingLevelsOnly = supportsThinking && details?.family === 'gptoss';
+
+  return { contextLength, supportsVision, supportsToolCalling, supportsThinking, thinkingLevelsOnly };
 }
 
 /**

--- a/src/stores/remoteServerHelpers.ts
+++ b/src/stores/remoteServerHelpers.ts
@@ -388,6 +388,7 @@ export async function fetchModelsFromServer(
                 modelInfos[i].supportsToolCalling ??
                 detectToolCallingCapability(model.id),
             supportsThinking: modelInfos[i].supportsThinking ?? false,
+            thinkingLevelsOnly: modelInfos[i].thinkingLevelsOnly,
             acceptsThinkingKwarg: modelInfos[i].acceptsThinkingKwarg ?? false,
             maxContextLength: modelInfos[i].contextLength,
           },
@@ -420,6 +421,7 @@ export async function fetchModelsFromServer(
                 modelInfos[i].supportsToolCalling ??
                 detectToolCallingCapability(model.name),
               supportsThinking: modelInfos[i].supportsThinking ?? false,
+              thinkingLevelsOnly: modelInfos[i].thinkingLevelsOnly,
               acceptsThinkingKwarg: modelInfos[i].acceptsThinkingKwarg ?? false,
               maxContextLength: modelInfos[i].contextLength,
             },
@@ -471,6 +473,7 @@ export async function fetchModelsFromServer(
                 modelInfos[i].supportsToolCalling ??
                 detectToolCallingCapability(model.name),
               supportsThinking: modelInfos[i].supportsThinking ?? false,
+              thinkingLevelsOnly: modelInfos[i].thinkingLevelsOnly,
               acceptsThinkingKwarg: modelInfos[i].acceptsThinkingKwarg ?? false,
               maxContextLength: modelInfos[i].contextLength,
             },

--- a/src/stores/remoteServerHelpers.ts
+++ b/src/stores/remoteServerHelpers.ts
@@ -324,6 +324,7 @@ export async function fetchModelsFromServer(
   server: RemoteServer,
 ): Promise<RemoteModel[]> {
   const url = trimTrailingSlashes(server.endpoint);
+  const isOpenRouter = new URL(url).hostname === 'openrouter.ai';
 
   // Headers for authentication
   const headers: Record<string, string> = {
@@ -350,13 +351,26 @@ export async function fetchModelsFromServer(
       };
 
       // OpenAI format: { object: "list", data: [{ id, object, owned_by, ... }] }
-      if (data?.object === 'list' && Array.isArray(data.data)) {
+      if ((data?.object === 'list' || isOpenRouter) && Array.isArray(data.data)) {
         const generativeModels = data.data.filter(
           (model: { id: string; kind?: unknown }) => isTextModel(model),
         );
         const modelInfos = await Promise.all(
-          generativeModels.map((model: { id: string }) =>
-            fetchModelCapabilities(url, model.id, nameDetect),
+          generativeModels.map((model: {
+            id: string;
+            context_length?: number;
+            architecture?: { input_modalities?: string[] };
+            supported_parameters?: string[];
+            reasoning?: { mandatory?: boolean };
+          }) =>
+            isOpenRouter
+              ? {
+                  contextLength: model.context_length ?? 4096,
+                  supportsVision: model.architecture?.input_modalities?.includes('image') === true,
+                  supportsToolCalling: model.supported_parameters?.includes('tools') === true,
+                  supportsThinking: !!model.reasoning && model.reasoning.mandatory !== true,
+                }
+              : fetchModelCapabilities(url, model.id, nameDetect),
           ),
         );
         return generativeModels.map(

--- a/src/types/remoteServer.ts
+++ b/src/types/remoteServer.ts
@@ -105,6 +105,8 @@ interface RemoteModelCapabilities {
    * reasoning per request (discovered from the server, e.g. llama.cpp /props).
    */
   acceptsThinkingKwarg?: boolean;
+  /** Ollama model accepts only low/medium/high thinking levels. */
+  thinkingLevelsOnly?: boolean;
   /** Maximum context window length */
   maxContextLength?: number;
   /** Model family or type hint */


### PR DESCRIPTION
## Summary
- Pass the existing Thinking toggle and budget through simple and tool-loop remote generation.
- Use discovered Ollama capability for level-only models, with no new UI.
- Cover Boolean and level-only behavior through rendered Mobile chat journeys.
- Make the normal push hook find local lint tools and stop on failed checks; update two stale settings help-text expectations.

## Verification
- Normal pre-push hook passed: lint, TypeScript, 158 related UI tests, dependency-cruiser, and knip.
- Focused remote reasoning UI journeys passed.
- No E2E tests run.